### PR TITLE
ci(generator): fix generator pack

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,6 +30,7 @@ jobs:
       # Deploy the site
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: publish/wwwroot

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -118,9 +118,11 @@ partial class Build : NukeBuild
             // Clean projects
             DotNetClean(c => c.SetProject(Solution.library.Ducky));
             DotNetClean(c => c.SetProject(Solution.library.Ducky_Blazor));
+            DotNetClean(c => c.SetProject(Solution.library.Ducky_Generator));
 
             DotNetClean(c => c.SetProject(Solution.tests.AppStore_Tests));
             DotNetClean(c => c.SetProject(Solution.tests.Ducky_Tests));
+            DotNetClean(c => c.SetProject(Solution.tests.Ducky_Generator_Tests));
             
             DotNetClean(c => c.SetProject(Solution.demo.Demo_BlazorWasm));
             
@@ -197,7 +199,8 @@ partial class Build : NukeBuild
             Project[] projectsToPack =
             [
                 Solution.library.Ducky,
-                Solution.library.Ducky_Blazor
+                Solution.library.Ducky_Blazor,
+                Solution.library.Ducky_Generator
             ];
 
             foreach (var project in projectsToPack)
@@ -317,22 +320,4 @@ partial class Build : NukeBuild
         };
         await GitHubTasks.GitHubClient.Repository.Release.UploadAsset(release, assetUpload);
     }
-    
-    // TODO: Validate this target
-    Target PublishToGitHubPages => _ => _
-        .Description("Publish demo to GitHub Pages")
-        .Requires(() => Configuration.Equals(Configuration.Release))
-        .OnlyWhenStatic(() => GitRepository.IsOnMainOrMasterBranch())
-        .Executes(() =>
-        {
-            // Publish the site
-            DotNetPublish(s => s
-                .SetProject(Solution.demo.Demo_BlazorWasm)
-                .SetConfiguration(Configuration.Release)
-                .SetOutput(ArtifactsDirectory / "public")
-                .SetProperty("GHPages", true)
-            );
-            
-            // TODO: Deploy the site
-        });
 }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="9.0.4" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.2" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NuGetAuditMode>direct</NuGetAuditMode>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
@@ -12,7 +13,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />

--- a/src/library/Ducky.Generator/Ducky.Generator.csproj
+++ b/src/library/Ducky.Generator/Ducky.Generator.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
 
+    <DevelopmentDependency>true</DevelopmentDependency>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
 
@@ -14,12 +14,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(TargetPath)"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes several changes to the build configuration and project files. The most important changes involve the addition of new projects to the build process, the removal of an outdated GitHub Pages publishing target, and updates to package versions and project properties.

### Build process improvements:

* [`build/Build.cs`](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32R121-R125): Added `Ducky_Generator` and `Ducky_Generator_Tests` to the `DotNetClean` targets and included `Ducky_Generator` in the `projectsToPack` array. [[1]](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32R121-R125) [[2]](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32L200-R203)

### Removal of outdated targets:

* [`build/Build.cs`](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32L320-L337): Removed the `PublishToGitHubPages` target, which was marked as a TODO and not validated.

### Package and project updates:

* [`build/_build.csproj`](diffhunk://#diff-7b133e20a4f96a79bedd410be3af66b7cf9e75453baaa14cb68d3dd09da21dc6L16-R16): Updated the version of `System.Runtime.Serialization.Formatters` from `9.0.2` to `9.0.3`.
* [`src/Directory.Packages.props`](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11R5): Added `NuGetAuditMode` property set to `direct` and removed the `Microsoft.CodeAnalysis.CSharp.Workspaces` package version. [[1]](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11R5) [[2]](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11L15)
* [`src/library/Ducky.Generator/Ducky.Generator.csproj`](diffhunk://#diff-6bc1e97f25f6aab090ae75996e0015126e94db0565eb8fd05a09850a28e89348L5-R8): Set `DevelopmentDependency` to `true`, added `PrivateAssets="all"` to `Microsoft.CodeAnalysis` package references, and included a `None` item to pack the target path as an analyzer. [[1]](diffhunk://#diff-6bc1e97f25f6aab090ae75996e0015126e94db0565eb8fd05a09850a28e89348L5-R8) [[2]](diffhunk://#diff-6bc1e97f25f6aab090ae75996e0015126e94db0565eb8fd05a09850a28e89348L17-R25)

### Workflow update:

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45R33): Added a condition to deploy only when the branch is `main`.