### PR TITLE
ci: fix NU1008 in generator

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,9 +11,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.AnalyzerUtilities" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3" />

--- a/src/library/Ducky.Generator/Ducky.Generator.csproj
+++ b/src/library/Ducky.Generator/Ducky.Generator.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.AnalyzerUtilities" Version="3.3.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.AnalyzerUtilities" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>
   </ItemGroup>
 


### PR DESCRIPTION
This pull request includes updates to package versions and dependencies in the project files. The most important changes include adding a new package version, removing an outdated package version, and updating the version specification for a package.

Updates to package versions and dependencies:

* [`src/Directory.Packages.props`](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11R14-L16): Added `Microsoft.CodeAnalysis.AnalyzerUtilities` version `3.3.4` and removed `Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit` version `1.1.2`.
* [`src/library/Ducky.Generator/Ducky.Generator.csproj`](diffhunk://#diff-6bc1e97f25f6aab090ae75996e0015126e94db0565eb8fd05a09850a28e89348L25-R25): Removed the version specification for `Microsoft.CodeAnalysis.AnalyzerUtilities` to use the default version.