### PR TITLE
chore: upgrade MudBlazor package

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MudBlazor" Version="8.5.0" />
+    <PackageVersion Include="MudBlazor" Version="8.5.1" />
     <PackageVersion Include="ObservableCollections" Version="3.3.3" />
     <PackageVersion Include="ObservableCollections.R3" Version="3.3.3" />
     <PackageVersion Include="PublishSPAforGitHubPages.Build" Version="3.0.0" />


### PR DESCRIPTION
This pull request includes a minor update to the `MudBlazor` package version in the `src/Directory.Packages.props` file. The package version has been incremented from `8.5.0` to `8.5.1` to include the latest improvements and bug fixes.

Version update:

* [`src/Directory.Packages.props`](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11L30-R30): Updated `MudBlazor` package version from `8.5.0` to `8.5.1`.