### PR TITLE
chore: downgrade Microsoft.CodeAnalysis.* packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,9 +12,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.AnalyzerUtilities" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />


### PR DESCRIPTION
This pull request includes a version downgrade for several `Microsoft.CodeAnalysis` packages in the `src/Directory.Packages.props` file. The changes are as follows:

* Downgraded `Microsoft.CodeAnalysis.CSharp` from version 4.13.0 to 4.12.0.
* Downgraded `Microsoft.CodeAnalysis.CSharp.Workspaces` from version 4.13.0 to 4.12.0.
* Downgraded `Microsoft.CodeAnalysis.Workspaces.Common` from version 4.13.0 to 4.12.0.