### PR TITLE
fix(build): remove SuppressBuildProjectCheck removed in Nuke.Common 10.x

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -83,7 +83,7 @@ partial class Build : NukeBuild
     [GitRepository]
     readonly GitRepository GitRepository;
     
-    [Solution(SuppressBuildProjectCheck = true, GenerateProjects = true)]
+    [Solution(GenerateProjects = true)]
     readonly Solution Solution;
     
     const string MainBranch = "main";


### PR DESCRIPTION
## Problem

The Ducky `continuous` CI workflow has been failing since Renovate merged Nuke.Common to v10.1.0.

**Error:**
```
/build/Build.cs(86,15): error CS0246: The type or namespace name 'SuppressBuildProjectCheck'
could not be found (are you missing a using directive or an assembly reference?)
```

## Root Cause

The `SuppressBuildProjectCheck` parameter was removed from the `[Solution]` attribute in Nuke.Common 10.x. The build was referencing a property that no longer exists.

## Fix

Remove `SuppressBuildProjectCheck = true` from the `[Solution]` attribute. The `GenerateProjects = true` parameter remains unchanged.

## Impact

- Fixes the `continuous` workflow CI failure
- No functional change to the build process