### PR TITLE
fix(build): install wasm-tools-net9 workload for net9.0 BlazorWasm project

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -135,8 +135,9 @@ partial class Build : NukeBuild
         .Description("Install .NET workloads")
         .Executes(() =>
         {
-            // this requires sudo on macOS and Linux
-            DotNetWorkloadInstall(s => s.SetWorkloadId("wasm-tools"));
+            // Demo.BlazorWasm targets net9.0; with .NET 10 SDK the correct
+            // workload is wasm-tools-net9 (not wasm-tools which covers net10.0).
+            DotNetWorkloadInstall(s => s.SetWorkloadId("wasm-tools-net9"));
         });
 
     Target Restore => _ => _


### PR DESCRIPTION
## Problem

The `continuous` CI still fails after PR #132 fixed the `SuppressBuildProjectCheck` issue. The build now reaches the `Restore` target and hits a new error:

```
NETSDK1147: To build this project, the following workloads must be installed: wasm-tools-net9
[src/demo/Demo.BlazorWasm/Demo.BlazorWasm.csproj]
```

## Root Cause

`Demo.BlazorWasm` targets `net9.0` (from `src/build/dotnet/common.props`) with `RunAOTCompilation=true`. With the .NET 10 SDK (pinned via `global.json`), the required workload for net9.0 WASM AOT is **`wasm-tools-net9`** — not `wasm-tools` which is for net10.0 targets.

The previous `SuppressBuildProjectCheck` compile error (fixed in #132) had been masking this issue since the build was failing before reaching the Restore target.

## Fix

Change the `InstallWorkloads` target to install `wasm-tools-net9` instead of `wasm-tools`.