### PR TITLE
fix(build): upgrade TargetFramework to net10.0 to match Renovate package bumps

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -135,9 +135,8 @@ partial class Build : NukeBuild
         .Description("Install .NET workloads")
         .Executes(() =>
         {
-            // Demo.BlazorWasm targets net9.0; with .NET 10 SDK the correct
-            // workload is wasm-tools-net9 (not wasm-tools which covers net10.0).
-            DotNetWorkloadInstall(s => s.SetWorkloadId("wasm-tools-net9"));
+            // Projects now target net10.0; use the standard wasm-tools workload.
+            DotNetWorkloadInstall(s => s.SetWorkloadId("wasm-tools"));
         });
 
     Target Restore => _ => _

--- a/src/build/dotnet/common.props
+++ b/src/build/dotnet/common.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- General -->
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>


### PR DESCRIPTION
## Problem

After fixing `SuppressBuildProjectCheck` (#132) and the wasm workload (#133), the `continuous` CI still fails with:

```
NU1202: Package Microsoft.AspNetCore.Components.WebAssembly 10.0.3 is not compatible with
net9.0 (.NETCoreApp,Version=v9.0). Package supports: net10.0 (.NETCoreApp,Version=v10.0)
```

Multiple projects are affected: Demo.BlazorWasm, Ducky.Blazor, AppStore.Tests.

## Root Cause

Renovate merged all Microsoft 10.x packages to 10.0.3 (in `Directory.Packages.props`):
- `Microsoft.AspNetCore.Components.WebAssembly` → 10.0.3 (net10.0 only)
- `Microsoft.AspNetCore.Components.Web` → 10.0.3 (net10.0 only)
- `Microsoft.Extensions.*` → 10.0.3
- etc.

But `src/build/dotnet/common.props` still specified `<TargetFramework>net9.0</TargetFramework>`.

## Fix

- Upgrade `TargetFramework` from `net9.0` → `net10.0` in `common.props` (aligns with `global.json` SDK 10.0.103)
- Revert `InstallWorkloads` back to `wasm-tools` (net10.0 WASM projects use `wasm-tools`, not `wasm-tools-net9`)