### PR TITLE
fix: use latestPatch rollForward policy in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.103",
-    "rollForward": "latestMajor",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Summary
- The `continuous` workflow on `develop` fails because GitHub Actions runners have SDK 10.0.102 while `global.json` pins 10.0.103
- Changes `rollForward` from `"latestMajor"` to `"latestPatch"` so the SDK resolver accepts any compatible patch version in the 10.0.1xx feature band
- This unblocks CI without changing the target SDK version

## Test plan
- [ ] Verify the `continuous` workflow passes on this PR branch
- [ ] Confirm `dotnet --version` resolves correctly on the runner