### PR TITLE
fix: update target framework to net10.0 and fix CI SDK resolution

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -42,6 +42,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v5
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
       - name: Install .NET WebAssembly Tools
         run: dotnet workload install wasm-tools
 

--- a/.run/Demo.BlazorWasm_ http.run.xml
+++ b/.run/Demo.BlazorWasm_ http.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Demo.BlazorWasm: http" type="LaunchSettings" factoryName=".NET Launch Settings Profile">
     <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/src/demo/Demo.BlazorWasm/Demo.BlazorWasm.csproj" />
-    <option name="LAUNCH_PROFILE_TFM" value="net9.0" />
+    <option name="LAUNCH_PROFILE_TFM" value="net10.0" />
     <option name="LAUNCH_PROFILE_NAME" value="http" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />

--- a/.run/Demo.BlazorWasm_ https.run.xml
+++ b/.run/Demo.BlazorWasm_ https.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Demo.BlazorWasm: https" type="LaunchSettings" factoryName=".NET Launch Settings Profile">
     <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/src/demo/Demo.BlazorWasm/Demo.BlazorWasm.csproj" />
-    <option name="LAUNCH_PROFILE_TFM" value="net9.0" />
+    <option name="LAUNCH_PROFILE_TFM" value="net10.0" />
     <option name="LAUNCH_PROFILE_NAME" value="https" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />

--- a/.run/_build.run.xml
+++ b/.run/_build.run.xml
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net9.0" />
+    <option name="PROJECT_TFM" value="net10.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -75,7 +75,7 @@ partial class Build : NukeBuild
     [OctoVersion(
         AutoDetectBranch = true,
         UpdateBuildNumber = true,
-        Framework = "net9.0",
+        Framework = "net10.0",
         Major = 1)]
     readonly OctoVersionInfo OctoVersionInfo;
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -82,7 +82,7 @@ partial class Build : NukeBuild
     [GitRepository]
     readonly GitRepository GitRepository;
     
-    [Solution(SuppressBuildProjectCheck = true, GenerateProjects = true)]
+    [Solution(GenerateProjects = true)]
     readonly Solution Solution;
     
     const string MainBranch = "main";

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.103",
-    "rollForward": "latestPatch",
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/src/build/dotnet/common.props
+++ b/src/build/dotnet/common.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- General -->
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>


### PR DESCRIPTION
## Summary

- **Root cause**: PRs #170 and #171 upgraded all NuGet packages to .NET 10 versions (Nuke.Common 10.1.0, Microsoft.AspNetCore.* 10.0.3, etc.) but the `TargetFramework` remained `net9.0`, causing the Nuke build project to fail with CS0246 errors because the packages are incompatible with the net9.0 TFM.
- **TargetFramework update**: Changed `net9.0` to `net10.0` in `_build.csproj`, `common.props`, `Build.cs` (OctoVersion), and JetBrains IDE run configs.
- **global.json fix**: Lowered the minimum SDK version to `10.0.100` with `latestFeature` rollForward policy, so any 10.0.x SDK installed on the runner will be accepted (not just 10.0.103).
- **CI workflows**: Added `actions/setup-dotnet@v5` with `10.0.x` to `continuous.yml` (was missing entirely), and updated `gh-pages.yml` from `9.0.x` to `10.0.x`.

## Test plan

- [ ] CI workflow passes on this PR (the `ci.yml` workflow runs on PRs to develop)
- [ ] Verify that the Nuke build project compiles and `UnitTests` target succeeds
- [ ] Verify no remaining `net9.0` references in project files