### PR TITLE
fix: correct NormalizedState string key validation in RemoveOne and ContainsKey

### DIFF
--- a/src/library/Ducky/Normalization/NormalizedState.cs
+++ b/src/library/Ducky/Normalization/NormalizedState.cs
@@ -106,7 +106,7 @@ public abstract record NormalizedState<TKey, TEntity, TState>
     {
         ArgumentNullException.ThrowIfNull(key);
 
-        return key is string
+        return key is string s && string.IsNullOrEmpty(s)
             ? throw new DuckyException("The key cannot be empty.")
             : CreateWith(ById.Remove(key));
     }
@@ -225,7 +225,7 @@ public abstract record NormalizedState<TKey, TEntity, TState>
     {
         ArgumentNullException.ThrowIfNull(key);
 
-        return key is string
+        return key is string s && string.IsNullOrEmpty(s)
             ? throw new DuckyException("The key cannot be empty.")
             : ById.ContainsKey(key);
     }

--- a/src/tests/Ducky.Tests/Extensions/Normalization/NormalizedStateTests.cs
+++ b/src/tests/Ducky.Tests/Extensions/Normalization/NormalizedStateTests.cs
@@ -75,6 +75,32 @@ public class NormalizedStateTests
     }
 
     [Fact]
+    public void ContainsKey_WithStringKey_ShouldReturnTrue_WhenEntityExists()
+    {
+        // Arrange
+        SampleStringState state = new SampleStringState().SetOne(new SampleStringEntity("key-1", "Test Entity"));
+
+        // Act
+        bool containsKey = state.ContainsKey("key-1");
+
+        // Assert
+        containsKey.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ContainsKey_WithStringKey_ShouldReturnFalse_WhenEntityDoesNotExist()
+    {
+        // Arrange
+        SampleStringState state = new();
+
+        // Act
+        bool containsKey = state.ContainsKey("non-existent-key");
+
+        // Assert
+        containsKey.ShouldBeFalse();
+    }
+
+    [Fact]
     public void GetByKey_ShouldReturnEntity_WhenEntityExists()
     {
         // Arrange
@@ -336,6 +362,33 @@ public class NormalizedStateTests
 
         // Assert
         act.ShouldThrow<DuckyException>("The key cannot be empty.");
+    }
+
+    [Fact]
+    public void RemoveOne_WithStringKey_ShouldRemoveEntity()
+    {
+        // Arrange
+        SampleStringEntity entity = new("key-1", "Test Entity");
+        SampleStringState state = new SampleStringState().AddOne(entity);
+
+        // Act
+        SampleStringState newState = state.RemoveOne("key-1");
+
+        // Assert
+        newState.ById.ShouldNotContainKey("key-1");
+    }
+
+    [Fact]
+    public void RemoveOne_WithNullStringKey_ShouldThrowException()
+    {
+        // Arrange
+        SampleStringState state = new();
+
+        // Act
+        Action act = () => state.RemoveOne(null!);
+
+        // Assert
+        act.ShouldThrow<ArgumentNullException>();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fixed `RemoveOne` and `ContainsKey` in `NormalizedState` which threw for **all** string keys, not just empty ones
- Changed `key is string` (type check, always true) to `key is string s && string.IsNullOrEmpty(s)` (value check)
- Added 4 unit tests for string-keyed NormalizedState operations

Closes #178

## Acceptance Criteria
- [x] `RemoveOne` works correctly with non-empty string keys
- [x] `ContainsKey` works correctly with non-empty string keys
- [x] Empty/null string keys still throw descriptive errors
- [x] Unit tests added for string-keyed NormalizedState operations

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test src/tests/Ducky.Tests` — 168 tests pass (164 existing + 4 new)
- [x] Grep confirms no remaining `key is string` bug pattern in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)