### PR TITLE
fix: remove NormalizedState Action<TEntity> overloads that violate immutability

### DIFF
--- a/Writerside/topics/advanced-topics/normalized-state.md
+++ b/Writerside/topics/advanced-topics/normalized-state.md
@@ -132,24 +132,22 @@ Here’s an overview of the key methods available in `NormalizedState`:
   var newState = state.RemoveMany(todoIds);
   ```
 
-- **UpdateOne**: Updates a single entity using an action or function.
+- **UpdateOne**: Updates a single entity using a function that returns the updated entity.
   ```C#
-  public TState UpdateOne(TKey key, Action<TEntity> update)
   public TState UpdateOne(TKey key, Func<TEntity, TEntity> update)
   ```
   Example:
   ```C#
-  var updatedState = state.UpdateOne(todoId, todo => todo.MarkAsCompleted());
+  var updatedState = state.UpdateOne(todoId, todo => todo with { IsCompleted = true });
   ```
 
-- **UpdateMany**: Updates multiple entities using an action or function.
+- **UpdateMany**: Updates multiple entities using a function that returns the updated entity.
   ```C#
-  public TState UpdateMany(IEnumerable<TKey> keys, Action<TEntity> update)
   public TState UpdateMany(IEnumerable<TKey> keys, Func<TEntity, TEntity> update)
   ```
   Example:
   ```C#
-  var updatedState = state.UpdateMany(todoIds, todo => todo.MarkAsCompleted());
+  var updatedState = state.UpdateMany(todoIds, todo => todo with { IsCompleted = true });
   ```
 
 - **UpsertOne**: Updates or inserts a single entity.
@@ -195,7 +193,7 @@ Here’s an overview of the key methods available in `NormalizedState`:
 var newState = state.AddOne(new TodoItem(Guid.NewGuid(), "New Task"));
 
 // Updating an existing todo item
-newState = newState.UpdateOne(todoId, todo => todo.MarkAsCompleted());
+newState = newState.UpdateOne(todoId, todo => todo with { IsCompleted = true });
 
 // Removing a todo item
 newState = newState.RemoveOne(todoId);

--- a/Writerside/topics/core-concepts/reducers.md
+++ b/Writerside/topics/core-concepts/reducers.md
@@ -121,7 +121,7 @@ public record TodoReducers : SliceReducers<TodoState>
 
     private static TodoState ReduceToggleTodo(TodoState state, ToggleTodo action)
     {
-        return state.UpdateOne(action.Payload.Id, todo => todo.IsCompleted = !todo.IsCompleted);
+        return state.UpdateOne(action.Payload.Id, todo => new TodoItem(todo.Id, todo.Title, !todo.IsCompleted));
     }
 
     private static TodoState ReduceDeleteTodo(TodoState state, DeleteTodo action)

--- a/src/demo/Demo.BlazorWasm/AppStore/Todos/TodoDucks.cs
+++ b/src/demo/Demo.BlazorWasm/AppStore/Todos/TodoDucks.cs
@@ -118,7 +118,7 @@ public record TodoReducers : SliceReducers<TodoState>
         => state.SetOne(new TodoItem(action.Payload.Title));
 
     private static TodoState Reduce(TodoState state, ToggleTodo action)
-        => state.UpdateOne(action.Payload.Id, todo => todo.IsCompleted = !todo.IsCompleted);
+        => state.UpdateOne(action.Payload.Id, todo => new TodoItem(todo.Id, todo.Title, !todo.IsCompleted));
 
     private static TodoState Reduce(TodoState state, DeleteTodo action)
         => state.RemoveOne(action.Payload.Id);

--- a/src/library/Ducky/Normalization/INormalizedStateCollectionMethods.cs
+++ b/src/library/Ducky/Normalization/INormalizedStateCollectionMethods.cs
@@ -89,36 +89,18 @@ public interface INormalizedStateCollectionMethods<in TKey, TEntity, out TState>
     /// Updates one entity in the collection. Supports partial updates.
     /// </summary>
     /// <param name="key">The key of the entity to update.</param>
-    /// <param name="update">The update action to apply to the entity.</param>
-    /// <returns>The new state with the entity updated.</returns>
-    /// <exception cref="ArgumentNullException">The key and update action must not be null.</exception>
-    TState UpdateOne(TKey key, Action<TEntity> update);
-
-    /// <summary>
-    /// Updates one entity in the collection. Supports partial updates.
-    /// </summary>
-    /// <param name="key">The key of the entity to update.</param>
     /// <param name="update">The update function to apply to the entity.</param>
     /// <returns>The new state with the entity updated.</returns>
-    /// <exception cref="ArgumentNullException">The key and update action must not be null.</exception>
+    /// <exception cref="ArgumentNullException">The key and update function must not be null.</exception>
     TState UpdateOne(TKey key, Func<TEntity, TEntity> update);
 
     /// <summary>
     /// Updates multiple entities in the collection. Supports partial updates.
     /// </summary>
     /// <param name="keys">The keys of the entities to update.</param>
-    /// <param name="update">The update action to apply to the entities.</param>
+    /// <param name="update">The update function to apply to the entities.</param>
     /// <returns>The new state with the entities updated.</returns>
-    /// <exception cref="ArgumentNullException">The keys collection and update action must not be null.</exception>
-    TState UpdateMany(IEnumerable<TKey> keys, Action<TEntity> update);
-
-    /// <summary>
-    /// Updates multiple entities in the collection. Supports partial updates.
-    /// </summary>
-    /// <param name="keys">The keys of the entities to update.</param>
-    /// <param name="update">The update action to apply to the entities.</param>
-    /// <returns>The new state with the entities updated.</returns>
-    /// <exception cref="ArgumentNullException">The keys collection and update action must not be null.</exception>
+    /// <exception cref="ArgumentNullException">The keys collection and update function must not be null.</exception>
     TState UpdateMany(IEnumerable<TKey> keys, Func<TEntity, TEntity> update);
 
     /// <summary>

--- a/src/library/Ducky/Normalization/NormalizedState.cs
+++ b/src/library/Ducky/Normalization/NormalizedState.cs
@@ -132,17 +132,6 @@ public abstract record NormalizedState<TKey, TEntity, TState>
     }
 
     /// <inheritdoc />
-    public TState UpdateOne(TKey key, Action<TEntity> update)
-    {
-        ArgumentNullException.ThrowIfNull(key);
-        ArgumentNullException.ThrowIfNull(update);
-
-        TEntity entity = GetByKey(key);
-        update(entity);
-        return CreateWith(ById.SetItem(key, entity));
-    }
-
-    /// <inheritdoc />
     public TState UpdateOne(TKey key, Func<TEntity, TEntity> update)
     {
         ArgumentNullException.ThrowIfNull(key);
@@ -151,23 +140,6 @@ public abstract record NormalizedState<TKey, TEntity, TState>
         TEntity entity = GetByKey(key);
         entity = update(entity);
         return CreateWith(ById.SetItem(key, entity));
-    }
-
-    /// <inheritdoc />
-    public TState UpdateMany(IEnumerable<TKey> keys, Action<TEntity> update)
-    {
-        ArgumentNullException.ThrowIfNull(keys);
-        ArgumentNullException.ThrowIfNull(update);
-
-        ImmutableDictionary<TKey, TEntity> byId = ById;
-        foreach (TKey key in keys)
-        {
-            TEntity entity = GetByKey(key);
-            update(entity);
-            byId = byId.SetItem(key, entity);
-        }
-
-        return CreateWith(byId);
     }
 
     /// <inheritdoc />

--- a/src/tests/Ducky.Tests/Extensions/Normalization/NormalizedStateTests.cs
+++ b/src/tests/Ducky.Tests/Extensions/Normalization/NormalizedStateTests.cs
@@ -393,20 +393,6 @@ public class NormalizedStateTests
     }
 
     [Fact]
-    public void UpdateOne_ShouldUpdateEntity()
-    {
-        // Arrange
-        SampleGuidEntity entity = CreateEntity(Guid.NewGuid(), "Test Entity");
-        SampleGuidState state = new SampleGuidState().AddOne(entity);
-
-        // Act
-        SampleGuidState newState = state.UpdateOne(entity.Id, e => e.Name = "Updated Entity");
-
-        // Assert
-        newState[entity.Id].Name.ShouldBe("Updated Entity");
-    }
-
-    [Fact]
     public void UpdateOne_WithFunc_ShouldUpdateEntity()
     {
         // Arrange
@@ -421,21 +407,20 @@ public class NormalizedStateTests
     }
 
     [Fact]
-    public void UpdateMany_ShouldUpdateEntities()
+    public void UpdateOne_ShouldPreserveImmutability()
     {
         // Arrange
-        List<SampleGuidEntity> entities =
-        [
-            CreateEntity(Guid.NewGuid(), "Entity 1"),
-            CreateEntity(Guid.NewGuid(), "Entity 2")
-        ];
-        SampleGuidState state = new SampleGuidState().AddMany(entities);
+        SampleGuidEntity entity = CreateEntity(Guid.NewGuid(), "Original Name");
+        SampleGuidState state = new SampleGuidState().AddOne(entity);
 
         // Act
-        SampleGuidState newState = state.UpdateMany(entities.Select(e => e.Id), e => e.Name = "Updated Entity");
+        SampleGuidState newState = state.UpdateOne(entity.Id, e => new SampleGuidEntity(e.Id, "Updated Name"));
 
-        // Assert
-        newState.ById.Values.ShouldAllBe(e => e.Name == "Updated Entity");
+        // Assert - new state has updated entity
+        newState[entity.Id].Name.ShouldBe("Updated Name");
+
+        // Assert - original state is unchanged (immutability preserved)
+        state[entity.Id].Name.ShouldBe("Original Name");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Remove `UpdateOne(TKey, Action<TEntity>)` and `UpdateMany(IEnumerable<TKey>, Action<TEntity>)` overloads that mutated entities in-place, corrupting previous state snapshots for class entities and silently discarding mutations for record entities
- Migrate the BlazorWasm demo `TodoDucks.cs` caller to the correct `Func<TEntity, TEntity>` overload
- Add immutability verification test confirming old state is unchanged after updates

Closes #179

## Acceptance Criteria
- [x] `Action<TEntity>` overloads of `UpdateOne` and `UpdateMany` are removed
- [x] `Func<TEntity, TEntity>` overloads remain and work correctly
- [x] Unit tests verify immutability is preserved after updates
- [x] Any callers of the removed overloads are migrated

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test src/tests/Ducky.Tests` — 163 tests pass
- [x] `dotnet test src/tests/AppStore.Tests` — 92 tests pass
- [x] Grep for `Action<TEntity>` in Normalization files — no remnants

🤖 Generated with [Claude Code](https://claude.com/claude-code)