### PR TITLE
fix: UpsertMany handles duplicate keys by overwriting

### DIFF
--- a/src/library/Ducky/Normalization/NormalizedState.cs
+++ b/src/library/Ducky/Normalization/NormalizedState.cs
@@ -198,7 +198,7 @@ public abstract record NormalizedState<TKey, TEntity, TState>
     public TState UpsertMany(params IEnumerable<TEntity> entities)
     {
         ArgumentNullException.ThrowIfNull(entities);
-        return CreateWith(ById.AddRange(entities.ToImmutableDictionary(entity => entity.Id)));
+        return CreateWith(ById.SetItems(entities.ToImmutableDictionary(entity => entity.Id)));
     }
 
     /// <inheritdoc />

--- a/src/tests/Ducky.Tests/Extensions/Normalization/NormalizedStateTests.cs
+++ b/src/tests/Ducky.Tests/Extensions/Normalization/NormalizedStateTests.cs
@@ -489,6 +489,42 @@ public class NormalizedStateTests
     }
 
     [Fact]
+    public void UpsertMany_ShouldOverwriteExistingEntities()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        SampleGuidState state = new SampleGuidState().AddOne(CreateEntity(id, "Original"));
+
+        // Act
+        SampleGuidState newState = state.UpsertMany([CreateEntity(id, "Updated")]);
+
+        // Assert
+        newState.ById.Count.ShouldBe(1);
+        newState.GetByKey(id).Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public void UpsertMany_ShouldInsertAndUpdateInSingleCall()
+    {
+        // Arrange
+        Guid existingId = Guid.NewGuid();
+        Guid newId = Guid.NewGuid();
+        SampleGuidState state = new SampleGuidState().AddOne(CreateEntity(existingId, "Original"));
+
+        // Act
+        SampleGuidState newState = state.UpsertMany(
+        [
+            CreateEntity(existingId, "Updated"),
+            CreateEntity(newId, "New Entity")
+        ]);
+
+        // Assert
+        newState.ById.Count.ShouldBe(2);
+        newState.GetByKey(existingId).Name.ShouldBe("Updated");
+        newState.GetByKey(newId).Name.ShouldBe("New Entity");
+    }
+
+    [Fact]
     public void MapOne_ShouldUpdateEntityUsingMapFunction()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- `UpsertMany` used `ImmutableDictionary.AddRange` which throws on duplicate keys
- Replaced with `SetItems` to correctly insert-or-update, matching `SetMany` behavior
- Added 2 unit tests covering overwrite and mixed insert+update scenarios

Closes #180

## Acceptance Criteria
- [x] `UpsertMany` correctly handles duplicate keys by overwriting
- [x] `UpsertMany` still works for new entities
- [x] Unit tests cover both insert and update scenarios in a single call

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 166 tests pass (2 new)
- [x] Existing `UpsertMany_ShouldAddOrUpdateEntities` still passes
- [x] New `UpsertMany_ShouldOverwriteExistingEntities` passes
- [x] New `UpsertMany_ShouldInsertAndUpdateInSingleCall` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)