### PR TITLE
fix: replace Console.WriteLine with ILogger in all library code

### DIFF
--- a/src/library/Ducky.Blazor/Middlewares/DevTools/DevToolsMiddleware.cs
+++ b/src/library/Ducky.Blazor/Middlewares/DevTools/DevToolsMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Ducky.Pipeline;
+using Microsoft.Extensions.Logging;
 
 namespace Ducky.Blazor.Middlewares.DevTools;
 
@@ -11,6 +12,7 @@ public sealed class DevToolsMiddleware : MiddlewareBase
 {
     private readonly ReduxDevToolsModule _devTools;
     private readonly DevToolsOptions _options;
+    private readonly ILogger<DevToolsMiddleware> _logger;
     private readonly object _syncRoot = new();
     private IStore? _store;
     private Task _tailTask = Task.CompletedTask;
@@ -21,10 +23,12 @@ public sealed class DevToolsMiddleware : MiddlewareBase
     /// Initializes a new instance of the <see cref="DevToolsMiddleware"/> class.
     /// </summary>
     /// <param name="devTools">The DevTools JSInterop module.</param>
+    /// <param name="logger">The logger instance.</param>
     /// <param name="options">The DevTools configuration options.</param>
-    public DevToolsMiddleware(ReduxDevToolsModule devTools, DevToolsOptions? options = null)
+    public DevToolsMiddleware(ReduxDevToolsModule devTools, ILogger<DevToolsMiddleware> logger, DevToolsOptions? options = null)
     {
         _devTools = devTools ?? throw new ArgumentNullException(nameof(devTools));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _options = options ?? new DevToolsOptions();
     }
 
@@ -124,9 +128,11 @@ public sealed class DevToolsMiddleware : MiddlewareBase
         _sequenceNumberOfCurrentState = actionIndex;
 
         // Log the jump operation for debugging
-        Console.WriteLine(
-            $"DevTools: Jumped to action index {actionIndex} "
-                + $"(current: {_sequenceNumberOfCurrentState}, latest: {_sequenceNumberOfLatestState})");
+        _logger.LogDebug(
+            "DevTools: Jumped to action index {ActionIndex} (current: {CurrentState}, latest: {LatestState})",
+            actionIndex,
+            _sequenceNumberOfCurrentState,
+            _sequenceNumberOfLatestState);
 
         // Note: The actual state restoration is handled by the DevTools module
         // which will dispatch appropriate actions through the normal pipeline
@@ -145,7 +151,7 @@ public sealed class DevToolsMiddleware : MiddlewareBase
         catch (Exception ex)
         {
             // Log but don't crash the application
-            Console.WriteLine($"Failed to send to DevTools: {ex.Message}");
+            _logger.LogWarning(ex, "Failed to send to DevTools");
         }
     }
 

--- a/src/library/Ducky.Blazor/Middlewares/DevTools/DevToolsReducer.cs
+++ b/src/library/Ducky.Blazor/Middlewares/DevTools/DevToolsReducer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 
 namespace Ducky.Blazor.Middlewares.DevTools;
 
@@ -9,14 +10,17 @@ namespace Ducky.Blazor.Middlewares.DevTools;
 public class DevToolsReducer
 {
     private readonly DevToolsStateManager _stateManager;
+    private readonly ILogger<DevToolsReducer> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DevToolsReducer"/> class.
     /// </summary>
     /// <param name="stateManager">The state manager for serialization/deserialization.</param>
-    public DevToolsReducer(DevToolsStateManager stateManager)
+    /// <param name="logger">The logger instance.</param>
+    public DevToolsReducer(DevToolsStateManager stateManager, ILogger<DevToolsReducer> logger)
     {
         _stateManager = stateManager ?? throw new ArgumentNullException(nameof(stateManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     /// <summary>
@@ -70,9 +74,9 @@ public class DevToolsReducer
     /// <param name="currentState">The current state.</param>
     /// <param name="jumpAction">The jump action.</param>
     /// <returns>The current state (no change for now).</returns>
-    private static IStateProvider HandleJumpToAction(IStateProvider currentState, DevToolsActions.JumpToAction jumpAction)
+    private IStateProvider HandleJumpToAction(IStateProvider currentState, DevToolsActions.JumpToAction jumpAction)
     {
-        Console.WriteLine($"DevTools: Jump to action {jumpAction.ActionIndex} ({jumpAction.ActionType})");
+        _logger.LogDebug("DevTools: Jump to action {ActionIndex} ({ActionType})", jumpAction.ActionIndex, jumpAction.ActionType);
 
         // TODO: Implement action replay from stored history
         // This would require:
@@ -91,9 +95,12 @@ public class DevToolsReducer
     /// <param name="currentState">The current state.</param>
     /// <param name="replayAction">The replay action.</param>
     /// <returns>The current state (no change for now).</returns>
-    private static IStateProvider HandleReplayActions(IStateProvider currentState, DevToolsActions.ReplayActions replayAction)
+    private IStateProvider HandleReplayActions(IStateProvider currentState, DevToolsActions.ReplayActions replayAction)
     {
-        Console.WriteLine($"DevTools: Replay actions from {replayAction.FromActionIndex} to {replayAction.ToActionIndex}");
+        _logger.LogDebug(
+            "DevTools: Replay actions from {FromIndex} to {ToIndex}",
+            replayAction.FromActionIndex,
+            replayAction.ToActionIndex);
 
         // TODO: Implement action range replay
         // This would require:
@@ -110,9 +117,9 @@ public class DevToolsReducer
     /// </summary>
     /// <param name="currentState">The current state.</param>
     /// <returns>The current state (no change for now).</returns>
-    private static IStateProvider HandleCommitState(IStateProvider currentState)
+    private IStateProvider HandleCommitState(IStateProvider currentState)
     {
-        Console.WriteLine("DevTools: Commit state handled in reducer");
+        _logger.LogDebug("DevTools: Commit state handled in reducer");
 
         // The actual commit operation is handled in the ReduxDevToolsModule
         // by updating the initial state in the state manager
@@ -125,9 +132,9 @@ public class DevToolsReducer
     /// </summary>
     /// <param name="currentState">The current state.</param>
     /// <returns>The current state (no change for now).</returns>
-    private static IStateProvider HandleRollbackToCommitted(IStateProvider currentState)
+    private IStateProvider HandleRollbackToCommitted(IStateProvider currentState)
     {
-        Console.WriteLine("DevTools: Rollback to committed state");
+        _logger.LogDebug("DevTools: Rollback to committed state");
 
         // TODO: Implement rollback to last committed state
         // This would require:
@@ -143,9 +150,9 @@ public class DevToolsReducer
     /// </summary>
     /// <param name="currentState">The current state.</param>
     /// <returns>The current state (no change for now).</returns>
-    private static IStateProvider HandleSweepSkippedActions(IStateProvider currentState)
+    private IStateProvider HandleSweepSkippedActions(IStateProvider currentState)
     {
-        Console.WriteLine("DevTools: Sweep skipped actions");
+        _logger.LogDebug("DevTools: Sweep skipped actions");
 
         // TODO: Implement sweeping of skipped actions
         // This would require:
@@ -163,9 +170,9 @@ public class DevToolsReducer
     /// <param name="currentState">The current state.</param>
     /// <param name="toggleAction">The toggle action.</param>
     /// <returns>The current state (no change for now).</returns>
-    private static IStateProvider HandleToggleAction(IStateProvider currentState, DevToolsActions.ToggleAction toggleAction)
+    private IStateProvider HandleToggleAction(IStateProvider currentState, DevToolsActions.ToggleAction toggleAction)
     {
-        Console.WriteLine($"DevTools: Toggle action at index {toggleAction.ActionIndex}");
+        _logger.LogDebug("DevTools: Toggle action at index {ActionIndex}", toggleAction.ActionIndex);
 
         // TODO: Implement action toggling (skip/unskip)
         // This would require:
@@ -183,10 +190,10 @@ public class DevToolsReducer
     /// <param name="currentState">The current state.</param>
     /// <param name="recordingAction">The recording control action.</param>
     /// <returns>The current state (no change for now).</returns>
-    private static IStateProvider HandleRecordingControl(IStateProvider currentState, DevToolsActions.RecordingControl recordingAction)
+    private IStateProvider HandleRecordingControl(IStateProvider currentState, DevToolsActions.RecordingControl recordingAction)
     {
         string status = recordingAction.IsPaused ? "paused" : recordingAction.IsLocked ? "locked" : "resumed";
-        Console.WriteLine($"DevTools: Recording {status}");
+        _logger.LogDebug("DevTools: Recording {Status}", status);
 
         // TODO: Implement recording control
         // This would require:

--- a/src/library/Ducky.Blazor/Middlewares/DevTools/DevToolsStateManager.cs
+++ b/src/library/Ducky.Blazor/Middlewares/DevTools/DevToolsStateManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace Ducky.Blazor.Middlewares.DevTools;
 
@@ -10,13 +11,16 @@ namespace Ducky.Blazor.Middlewares.DevTools;
 public class DevToolsStateManager
 {
     private readonly JsonSerializerOptions _jsonOptions;
+    private readonly ILogger<DevToolsStateManager> _logger;
     private ImmutableSortedDictionary<string, object>? _initialState;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DevToolsStateManager"/> class.
     /// </summary>
-    public DevToolsStateManager()
+    /// <param name="logger">The logger instance.</param>
+    public DevToolsStateManager(ILogger<DevToolsStateManager> logger)
     {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _jsonOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -50,7 +54,7 @@ public class DevToolsStateManager
         catch (Exception ex)
         {
             // Log error and return empty state if serialization fails
-            Console.WriteLine($"DevTools state serialization failed: {ex.Message}");
+            _logger.LogWarning(ex, "DevTools state serialization failed");
             return "{}";
         }
     }
@@ -96,7 +100,7 @@ public class DevToolsStateManager
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"DevTools state deserialization failed: {ex.Message}");
+            _logger.LogWarning(ex, "DevTools state deserialization failed");
             return _initialState;
         }
     }

--- a/src/library/Ducky.Blazor/Middlewares/DevTools/ReduxDevToolsModule.cs
+++ b/src/library/Ducky.Blazor/Middlewares/DevTools/ReduxDevToolsModule.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
 namespace Ducky.Blazor.Middlewares.DevTools;
@@ -13,6 +14,7 @@ public class ReduxDevToolsModule : JsModule
     private IDispatcher? _dispatcher;
     private readonly DevToolsOptions _options;
     private readonly DevToolsStateManager _stateManager;
+    private readonly ILogger<ReduxDevToolsModule> _logger;
     private bool _enabled;
     private readonly TaskCompletionSource<bool> _readyTcs = new();
 
@@ -45,14 +47,17 @@ public class ReduxDevToolsModule : JsModule
     /// </summary>
     /// <param name="js">The Blazor JS runtime.</param>
     /// <param name="stateManager">The state manager for serialization.</param>
+    /// <param name="logger">The logger instance.</param>
     /// <param name="options">Configuration options for DevTools.</param>
     public ReduxDevToolsModule(
         IJSRuntime js,
         DevToolsStateManager stateManager,
+        ILogger<ReduxDevToolsModule> logger,
         DevToolsOptions? options = default)
         : base(js, "./_content/Ducky.Blazor/reduxDevtools.js")
     {
         _stateManager = stateManager ?? throw new ArgumentNullException(nameof(stateManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _options = options ?? new DevToolsOptions();
     }
 
@@ -133,17 +138,7 @@ public class ReduxDevToolsModule : JsModule
             // DevTools initialization failed, but don't crash the application
             _enabled = false;
             _readyTcs.TrySetResult(false);
-
-            // Log the error if a logger is available
-            // This is optional and should not fail
-            try
-            {
-                Console.WriteLine($"DevTools initialization failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools initialization failed");
         }
     }
 
@@ -169,15 +164,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            // Log but don't crash the application
-            try
-            {
-                Console.WriteLine($"DevTools send failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools send failed");
         }
     }
 
@@ -203,15 +190,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            // Log but don't crash the application
-            try
-            {
-                Console.WriteLine($"DevTools send failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools send failed");
         }
     }
 
@@ -233,15 +212,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            // Log but don't crash the application
-            try
-            {
-                Console.WriteLine($"DevTools subscription failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools subscription failed");
         }
     }
 
@@ -256,7 +227,7 @@ public class ReduxDevToolsModule : JsModule
         {
             if (!_options.EnableTimeTravel)
             {
-                Console.WriteLine("DevTools time-travel is disabled");
+                _logger.LogDebug("DevTools time-travel is disabled");
                 return Task.CompletedTask;
             }
 
@@ -265,26 +236,19 @@ public class ReduxDevToolsModule : JsModule
 
             if (restoreAction is not null)
             {
-                Console.WriteLine($"DevTools: Restoring state from time-travel");
+                _logger.LogDebug("DevTools: Restoring state from time-travel");
 
                 // Dispatch the restore action through the normal pipeline
                 _dispatcher?.Dispatch(restoreAction);
             }
             else
             {
-                Console.WriteLine("DevTools: Failed to parse state for time-travel");
+                _logger.LogWarning("DevTools: Failed to parse state for time-travel");
             }
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools time-travel failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools time-travel failed");
         }
 
         return Task.CompletedTask;
@@ -300,11 +264,11 @@ public class ReduxDevToolsModule : JsModule
         {
             if (!_options.EnableTimeTravel)
             {
-                Console.WriteLine("DevTools time-travel is disabled");
+                _logger.LogDebug("DevTools time-travel is disabled");
                 return Task.CompletedTask;
             }
 
-            Console.WriteLine("DevTools: Resetting to initial state");
+            _logger.LogDebug("DevTools: Resetting to initial state");
 
             // Create and dispatch a reset action
             DevToolsActions.ResetToInitial resetAction = _stateManager.CreateResetAction();
@@ -312,14 +276,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools reset failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools reset failed");
         }
 
         return Task.CompletedTask;
@@ -337,11 +294,11 @@ public class ReduxDevToolsModule : JsModule
         {
             if (!_options.EnableTimeTravel)
             {
-                Console.WriteLine("DevTools time-travel is disabled");
+                _logger.LogDebug("DevTools time-travel is disabled");
                 return;
             }
 
-            Console.WriteLine($"DevTools: Jumping to action {actionIndex} ({actionType})");
+            _logger.LogDebug("DevTools: Jumping to action {ActionIndex} ({ActionType})", actionIndex, actionType);
 
             // Invoke the callback if set
             if (_onJumpToState is not null)
@@ -357,14 +314,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools jump to action failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools jump to action failed");
         }
     }
 
@@ -376,7 +326,7 @@ public class ReduxDevToolsModule : JsModule
     {
         try
         {
-            Console.WriteLine("DevTools: Commit current state as baseline");
+            _logger.LogDebug("DevTools: Commit current state as baseline");
 
             // Update the initial state to the current state
             if (_store is not null)
@@ -398,14 +348,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools commit failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools commit failed");
         }
     }
 
@@ -417,7 +360,7 @@ public class ReduxDevToolsModule : JsModule
     {
         try
         {
-            Console.WriteLine("DevTools: Rollback to committed state");
+            _logger.LogDebug("DevTools: Rollback to committed state");
 
             // Create and dispatch a rollback action
             DevToolsActions.RollbackToCommitted rollbackAction = new(DateTime.UtcNow);
@@ -425,14 +368,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools rollback failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools rollback failed");
         }
 
         return Task.CompletedTask;
@@ -446,7 +382,7 @@ public class ReduxDevToolsModule : JsModule
     {
         try
         {
-            Console.WriteLine("DevTools: Sweep skipped actions");
+            _logger.LogDebug("DevTools: Sweep skipped actions");
 
             // Create and dispatch a sweep action
             DevToolsActions.SweepSkippedActions sweepAction = new(DateTime.UtcNow);
@@ -454,14 +390,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools sweep failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools sweep failed");
         }
 
         return Task.CompletedTask;
@@ -476,7 +405,7 @@ public class ReduxDevToolsModule : JsModule
     {
         try
         {
-            Console.WriteLine($"DevTools: Toggle action at index {actionIndex}");
+            _logger.LogDebug("DevTools: Toggle action at index {ActionIndex}", actionIndex);
 
             // Create and dispatch a toggle action
             DevToolsActions.ToggleAction toggleAction = new(actionIndex, DateTime.UtcNow);
@@ -484,14 +413,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools toggle action failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools toggle action failed");
         }
 
         return Task.CompletedTask;
@@ -506,33 +428,26 @@ public class ReduxDevToolsModule : JsModule
     {
         try
         {
-            Console.WriteLine("DevTools: Import state");
+            _logger.LogDebug("DevTools: Import state");
 
             // Create a restore action from the imported JSON state
             DevToolsActions.RestoreState? importAction = _stateManager.CreateRestoreAction(jsonState);
 
             if (importAction is not null)
             {
-                Console.WriteLine("DevTools: Importing state from external source");
+                _logger.LogDebug("DevTools: Importing state from external source");
 
                 // Dispatch the import action through the normal pipeline
                 _dispatcher?.Dispatch(importAction);
             }
             else
             {
-                Console.WriteLine("DevTools: Failed to parse imported state");
+                _logger.LogWarning("DevTools: Failed to parse imported state");
             }
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools import state failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools import state failed");
         }
 
         return Task.CompletedTask;
@@ -549,7 +464,7 @@ public class ReduxDevToolsModule : JsModule
         try
         {
             string actionType = isPaused ? "pause recording" : isLocked ? "lock changes" : "resume recording";
-            Console.WriteLine($"DevTools: {actionType}");
+            _logger.LogDebug("DevTools: {ActionType}", actionType);
 
             // Create and dispatch a recording control action
             DevToolsActions.RecordingControl recordingAction = new(isPaused, isLocked, DateTime.UtcNow);
@@ -557,14 +472,7 @@ public class ReduxDevToolsModule : JsModule
         }
         catch (Exception ex)
         {
-            try
-            {
-                Console.WriteLine($"DevTools recording control failed: {ex.Message}");
-            }
-            catch
-            {
-                // Ignore logging errors
-            }
+            _logger.LogWarning(ex, "DevTools recording control failed");
         }
 
         return Task.CompletedTask;

--- a/src/library/Ducky.Blazor/Middlewares/Persistence/PersistenceMiddleware.cs
+++ b/src/library/Ducky.Blazor/Middlewares/Persistence/PersistenceMiddleware.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Ducky.Pipeline;
+using Microsoft.Extensions.Logging;
 
 namespace Ducky.Blazor.Middlewares.Persistence;
 
@@ -15,6 +16,7 @@ public sealed class PersistenceMiddleware : MiddlewareBase, IDisposable
     private readonly IEnhancedPersistenceProvider<Dictionary<string, object>> _persistenceProvider;
     private readonly HydrationManager _hydrationManager;
     private readonly PersistenceOptions _options;
+    private readonly ILogger<PersistenceMiddleware> _logger;
     private IDispatcher? _dispatcher;
     private IStore? _store;
 
@@ -42,14 +44,17 @@ public sealed class PersistenceMiddleware : MiddlewareBase, IDisposable
     /// <param name="persistenceProvider">The enhanced persistence provider.</param>
     /// <param name="hydrationManager">The hydration manager.</param>
     /// <param name="options">Configuration options for persistence.</param>
+    /// <param name="logger">The logger instance.</param>
     public PersistenceMiddleware(
         IEnhancedPersistenceProvider<Dictionary<string, object>> persistenceProvider,
         HydrationManager hydrationManager,
-        PersistenceOptions options)
+        PersistenceOptions options,
+        ILogger<PersistenceMiddleware> logger)
     {
         _persistenceProvider = persistenceProvider ?? throw new ArgumentNullException(nameof(persistenceProvider));
         _hydrationManager = hydrationManager ?? throw new ArgumentNullException(nameof(hydrationManager));
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         _isEnabled = _options.Enabled;
 
@@ -477,7 +482,7 @@ public sealed class PersistenceMiddleware : MiddlewareBase, IDisposable
             return;
         }
 
-        Console.WriteLine($"[PersistenceMiddleware] {DateTime.UtcNow:HH:mm:ss.fff} {message}");
+        _logger.LogDebug("[PersistenceMiddleware] {Message}", message);
     }
 
     /// <summary>

--- a/src/library/Ducky.Blazor/Middlewares/Persistence/TypedLocalStoragePersistenceProvider.cs
+++ b/src/library/Ducky.Blazor/Middlewares/Persistence/TypedLocalStoragePersistenceProvider.cs
@@ -5,6 +5,7 @@
 using System.Text;
 using System.Text.Json;
 using Blazored.LocalStorage;
+using Microsoft.Extensions.Logging;
 
 namespace Ducky.Blazor.Middlewares.Persistence;
 
@@ -14,6 +15,7 @@ namespace Ducky.Blazor.Middlewares.Persistence;
 public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider<Dictionary<string, object>>
 {
     private readonly ILocalStorageService _localStorage;
+    private readonly ILogger<TypedLocalStoragePersistenceProvider> _logger;
     private readonly string _key;
     private readonly string _metadataKey;
     private readonly JsonSerializerOptions _jsonOptions;
@@ -23,9 +25,11 @@ public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider
     /// </summary>
     public TypedLocalStoragePersistenceProvider(
         ILocalStorageService localStorage,
-        PersistenceOptions options)
+        PersistenceOptions options,
+        ILogger<TypedLocalStoragePersistenceProvider> logger)
     {
         _localStorage = localStorage ?? throw new ArgumentNullException(nameof(localStorage));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _key = options.StorageKey ?? "ducky:state";
         _metadataKey = $"{_key}:metadata";
 
@@ -59,13 +63,13 @@ public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider
 
             if (persistedDict?.Slices is null || persistedDict.Slices.Count == 0)
             {
-                Console.WriteLine("[TypedLocalStoragePersistenceProvider] No persisted state found");
+                _logger.LogDebug("No persisted state found");
                 return null;
             }
 
             // Reconstruct the state dictionary with proper types
             Dictionary<string, object> stateDict = [];
-            
+
             foreach ((string key, PersistedSlice slice) in persistedDict.Slices)
             {
                 try
@@ -74,7 +78,7 @@ public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider
                     Type? stateType = Type.GetType(slice.TypeName);
                     if (stateType is null)
                     {
-                        Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Could not find type: {slice.TypeName}");
+                        _logger.LogWarning("Could not find type: {TypeName}", slice.TypeName);
                         continue;
                     }
 
@@ -83,16 +87,16 @@ public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider
                     if (state is not null)
                     {
                         stateDict[key] = state;
-                        Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Loaded slice '{key}' with type {stateType.Name}");
+                        _logger.LogDebug("Loaded slice '{SliceKey}' with type {TypeName}", key, stateType.Name);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Failed to deserialize slice '{key}': {ex.Message}");
+                    _logger.LogError(ex, "Failed to deserialize slice '{SliceKey}'", key);
                 }
             }
 
-            Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Successfully loaded {stateDict.Count} slices");
+            _logger.LogDebug("Successfully loaded {SliceCount} slices", stateDict.Count);
 
             return new PersistedStateContainer<Dictionary<string, object>>
             {
@@ -102,7 +106,7 @@ public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Failed to load state: {ex.Message}");
+            _logger.LogError(ex, "Failed to load state");
             return null;
         }
     }
@@ -129,7 +133,7 @@ public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider
                     StateJson = stateJson
                 };
 
-                Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Saving slice '{key}' with type {value.GetType().Name}");
+                _logger.LogDebug("Saving slice '{SliceKey}' with type {TypeName}", key, value.GetType().Name);
             }
 
             // Save the dictionary and metadata
@@ -138,13 +142,13 @@ public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider
 
             await Task.WhenAll(dictTask, metadataTask).ConfigureAwait(false);
 
-            Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Successfully saved {state.Count} slices");
+            _logger.LogDebug("Successfully saved {SliceCount} slices", state.Count);
 
             return PersistenceResult.Successful();
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Failed to save state: {ex.Message}");
+            _logger.LogError(ex, "Failed to save state");
             return PersistenceResult.Failed(ex.Message);
         }
     }
@@ -163,7 +167,7 @@ public class TypedLocalStoragePersistenceProvider : IEnhancedPersistenceProvider
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[TypedLocalStoragePersistenceProvider] Failed to clear state: {ex.Message}");
+            _logger.LogError(ex, "Failed to clear state");
             return PersistenceResult.Failed(ex.Message);
         }
     }

--- a/src/library/Ducky.Reactive/Operators/CustomOperators.cs
+++ b/src/library/Ducky.Reactive/Operators/CustomOperators.cs
@@ -2,6 +2,8 @@
 // Atypical Consulting SRL licenses this file to you under the GPL-3.0-or-later license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.Extensions.Logging;
+
 namespace Ducky.Reactive;
 
 /// <summary>
@@ -110,16 +112,18 @@ public static class CustomOperators
     }
 
     /// <summary>
-    /// Logs a message to the console for each element in the observable sequence.
+    /// Logs a message for each element in the observable sequence using the provided logger.
     /// </summary>
     /// <typeparam name="TSource">The type of the source elements.</typeparam>
     /// <param name="source">The source observable sequence.</param>
-    /// <param name="message">The message to log to the console.</param>
+    /// <param name="logger">The logger to use for logging.</param>
+    /// <param name="message">The message to log.</param>
     /// <returns>The source sequence with added side-effects of logging each element.</returns>
     public static IObservable<TSource> LogMessage<TSource>(
         this IObservable<TSource> source,
+        ILogger logger,
         string message)
     {
-        return source.Do(_ => Console.WriteLine(message));
+        return source.Do(_ => logger.LogDebug("{Message}", message));
     }
 }

--- a/src/tests/Ducky.Blazor.Tests/DevToolsInitializationTests.cs
+++ b/src/tests/Ducky.Blazor.Tests/DevToolsInitializationTests.cs
@@ -1,4 +1,5 @@
 using FakeItEasy;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
 namespace Ducky.Blazor.Tests;
@@ -10,11 +11,11 @@ public class DevToolsInitializationTests
     {
         // Arrange
         IJSRuntime mockJsRuntime = A.Fake<IJSRuntime>();
-        DevToolsStateManager stateManager = new();
+        DevToolsStateManager stateManager = new(A.Fake<ILogger<DevToolsStateManager>>());
         DevToolsOptions options = new();
 
         // Act
-        ReduxDevToolsModule devTools = new(mockJsRuntime, stateManager, options);
+        ReduxDevToolsModule devTools = new(mockJsRuntime, stateManager, A.Fake<ILogger<ReduxDevToolsModule>>(), options);
 
         // Assert
         devTools.ShouldNotBeNull();
@@ -26,9 +27,9 @@ public class DevToolsInitializationTests
     {
         // Arrange
         IJSRuntime mockJsRuntime = A.Fake<IJSRuntime>();
-        DevToolsStateManager stateManager = new();
+        DevToolsStateManager stateManager = new(A.Fake<ILogger<DevToolsStateManager>>());
         DevToolsOptions options = new() { Enabled = false };
-        ReduxDevToolsModule devTools = new(mockJsRuntime, stateManager, options);
+        ReduxDevToolsModule devTools = new(mockJsRuntime, stateManager, A.Fake<ILogger<ReduxDevToolsModule>>(), options);
 
         // Act
         await devTools.InitAsync().ConfigureAwait(true);
@@ -46,9 +47,9 @@ public class DevToolsInitializationTests
     {
         // Arrange
         IJSRuntime mockJsRuntime = A.Fake<IJSRuntime>();
-        DevToolsStateManager stateManager = new();
-        ReduxDevToolsModule devTools = new(mockJsRuntime, stateManager);
-        DevToolsMiddleware middleware = new(devTools);
+        DevToolsStateManager stateManager = new(A.Fake<ILogger<DevToolsStateManager>>());
+        ReduxDevToolsModule devTools = new(mockJsRuntime, stateManager, A.Fake<ILogger<ReduxDevToolsModule>>());
+        DevToolsMiddleware middleware = new(devTools, A.Fake<ILogger<DevToolsMiddleware>>());
 
         IStore mockStore = A.Fake<IStore>();
         IDispatcher mockDispatcher = A.Fake<IDispatcher>();
@@ -67,6 +68,7 @@ public class DevToolsInitializationTests
 
         // Add required dependencies
         services.AddSingleton(A.Fake<IJSRuntime>());
+        services.AddLogging();
 
         // Save original environment variables
         string? originalAspNetCoreEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");

--- a/src/tests/Ducky.Blazor.Tests/Middlewares/Persistence/PersistenceMiddlewareTests.cs
+++ b/src/tests/Ducky.Blazor.Tests/Middlewares/Persistence/PersistenceMiddlewareTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Ducky.Blazor.Middlewares.Persistence;
 using FakeItEasy;
+using Microsoft.Extensions.Logging;
 
 namespace Ducky.Blazor.Tests.Middlewares.Persistence;
 
@@ -25,7 +26,11 @@ public class PersistenceMiddlewareTests : IDisposable
         A.CallTo(() => _store.GetStateDictionary())
             .Returns(ImmutableSortedDictionary<string, object>.Empty);
 
-        _middleware = new PersistenceMiddleware(_persistenceProvider, _hydrationManager, _options);
+        _middleware = new PersistenceMiddleware(
+            _persistenceProvider,
+            _hydrationManager,
+            _options,
+            A.Fake<ILogger<PersistenceMiddleware>>());
     }
 
     public void Dispose()
@@ -49,7 +54,11 @@ public class PersistenceMiddlewareTests : IDisposable
     {
         // Arrange - Create a new middleware with disabled options
         var disabledOptions = new PersistenceOptions { Enabled = false };
-        var disabledMiddleware = new PersistenceMiddleware(_persistenceProvider, _hydrationManager, disabledOptions);
+        var disabledMiddleware = new PersistenceMiddleware(
+            _persistenceProvider,
+            _hydrationManager,
+            disabledOptions,
+            A.Fake<ILogger<PersistenceMiddleware>>());
         
         await disabledMiddleware.InitializeAsync(_dispatcher, _store);
 

--- a/src/tests/Ducky.Blazor.Tests/Middlewares/Persistence/TypedLocalStoragePersistenceProviderTests.cs
+++ b/src/tests/Ducky.Blazor.Tests/Middlewares/Persistence/TypedLocalStoragePersistenceProviderTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Blazored.LocalStorage;
 using Ducky.Blazor.Middlewares.Persistence;
 using FakeItEasy;
+using Microsoft.Extensions.Logging;
 
 namespace Ducky.Blazor.Tests.Middlewares.Persistence;
 
@@ -15,7 +16,10 @@ public class TypedLocalStoragePersistenceProviderTests
     {
         _localStorage = A.Fake<ILocalStorageService>();
         _options = new PersistenceOptions { StorageKey = "test:state" };
-        _provider = new TypedLocalStoragePersistenceProvider(_localStorage, _options);
+        _provider = new TypedLocalStoragePersistenceProvider(
+            _localStorage,
+            _options,
+            A.Fake<ILogger<TypedLocalStoragePersistenceProvider>>());
     }
 
     [Fact]
@@ -23,7 +27,7 @@ public class TypedLocalStoragePersistenceProviderTests
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            new TypedLocalStoragePersistenceProvider(null!, _options));
+            new TypedLocalStoragePersistenceProvider(null!, _options, A.Fake<ILogger<TypedLocalStoragePersistenceProvider>>()));
     }
 
     [Fact]
@@ -33,7 +37,10 @@ public class TypedLocalStoragePersistenceProviderTests
         var optionsWithoutKey = new PersistenceOptions { StorageKey = null };
 
         // Act
-        var provider = new TypedLocalStoragePersistenceProvider(_localStorage, optionsWithoutKey);
+        var provider = new TypedLocalStoragePersistenceProvider(
+            _localStorage,
+            optionsWithoutKey,
+            A.Fake<ILogger<TypedLocalStoragePersistenceProvider>>());
 
         // Assert
         provider.ShouldNotBeNull();

--- a/src/tests/Ducky.Reactive.Tests/CustomOperatorsTests.cs
+++ b/src/tests/Ducky.Reactive.Tests/CustomOperatorsTests.cs
@@ -2,6 +2,9 @@
 // Atypical Consulting SRL licenses this file to you under the GPL-3.0-or-later license.
 // See the LICENSE file in the project root for full license information.
 
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+
 namespace Ducky.Reactive.Tests;
 
 public class CustomOperatorsTests
@@ -190,10 +193,11 @@ public class CustomOperatorsTests
         // Arrange
         Subject<int> source = new();
         List<int> results = [];
+        ILogger logger = A.Fake<ILogger>();
 
         // Act
         source
-            .LogMessage("Test message")
+            .LogMessage(logger, "Test message")
             .Subscribe(results.Add);
 
         source.OnNext(1);
@@ -203,7 +207,6 @@ public class CustomOperatorsTests
         // Assert
         results.Count.ShouldBe(3);
         results.ShouldBe([1, 2, 3]);
-        // Note: In a real test, you might want to capture console output to verify logging
     }
 
     // Test helper classes


### PR DESCRIPTION
## Summary
- Replace all 51 `Console.WriteLine` calls across 7 library files with `ILogger<T>` via constructor injection
- Log levels mapped appropriately: Debug for operational info, Warning for recoverable failures, Error for deserialization/load failures
- `CustomOperators.LogMessage` now accepts `ILogger` parameter (breaking API change)

Closes #181

## Acceptance Criteria
- [x] All `Console.WriteLine` calls in library code replaced with `ILogger`
- [x] `PersistenceMiddleware` accepts `ILogger<PersistenceMiddleware>` via constructor
- [x] `DevToolsMiddleware` accepts `ILogger<DevToolsMiddleware>` via constructor
- [x] Log levels used appropriately (Debug for verbose, Information for key events, Warning/Error for failures)
- [x] No `Console.WriteLine` remains in any library project (`Ducky`, `Ducky.Blazor`, `Ducky.Reactive`)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 416 tests pass (164 + 2 + 66 + 92 + 92)
- [x] `grep Console.Write src/library/` — 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)