### PR TITLE
fix: AsyncEffectMiddleware fire-and-forget swallows exceptions

### DIFF
--- a/src/codegen/Ducky.Generator.Core/Effects/EffectsGenerator.cs
+++ b/src/codegen/Ducky.Generator.Core/Effects/EffectsGenerator.cs
@@ -18,6 +18,7 @@ public class EffectsGenerator : SourceGeneratorBase<EffectsGeneratorOptions>
             [
                 "System",
                 "System.Reactive.Linq",
+                "System.Threading",
                 "System.Threading.Tasks",
                 "Ducky",
                 "Ducky.Abstractions",
@@ -124,7 +125,8 @@ public class EffectsGenerator : SourceGeneratorBase<EffectsGeneratorOptions>
             Parameters = new List<ParameterDescriptor>
             {
                 new() { ParamName = "action", ParamType = "object" },
-                new() { ParamName = "stateProvider", ParamType = "IStateProvider" }
+                new() { ParamName = "stateProvider", ParamType = "IStateProvider" },
+                new() { ParamName = "cancellationToken", ParamType = "CancellationToken" }
             },
             ExpressionBody = new ExpressionElement
             {

--- a/src/demo/Demo.BlazorWasm/AppStore/Counter/CounterDucks.cs
+++ b/src/demo/Demo.BlazorWasm/AppStore/Counter/CounterDucks.cs
@@ -59,7 +59,7 @@ public record CounterReducers : SliceReducers<CounterState>
 
 public class ResetCounterAfter3Sec : AsyncEffect<Increment>
 {
-    public override async Task HandleAsync(Increment action, IStateProvider stateProvider)
+    public override async Task HandleAsync(Increment action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
         CounterState counterState = stateProvider.GetSlice<CounterState>();
 
@@ -69,7 +69,7 @@ public class ResetCounterAfter3Sec : AsyncEffect<Increment>
             return;
         }
 
-        await Task.Delay(TimeSpan.FromSeconds(3));
+        await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
         Dispatcher.Reset();
     }
 }

--- a/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/DebouncedSearchEffect.cs
+++ b/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/DebouncedSearchEffect.cs
@@ -30,11 +30,11 @@ public class DebouncedSearchEffect : AsyncEffect<SearchMovies>
     }
 
     /// <inheritdoc />
-    public override async Task HandleAsync(SearchMovies action, IStateProvider stateProvider)
+    public override async Task HandleAsync(SearchMovies action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
         // Cancel any previous search
         _searchCancellationTokenSource?.Cancel();
-        _searchCancellationTokenSource = new CancellationTokenSource();
+        _searchCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         try
         {

--- a/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/ErrorRecoveryEffect.cs
+++ b/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/ErrorRecoveryEffect.cs
@@ -14,7 +14,10 @@ public class RetryFailedOperationEffect(
     ILogger<RetryFailedOperationEffect> logger)
     : AsyncEffect<RetryFailedOperation>
 {
-    public override Task HandleAsync(RetryFailedOperation action, IStateProvider stateProvider)
+    public override Task HandleAsync(
+        RetryFailedOperation action,
+        IStateProvider stateProvider,
+        CancellationToken cancellationToken = default)
     {
         logger.LogInformation(
             "Retrying failed operation: {ActionType}",
@@ -39,7 +42,7 @@ public class ReportErrorEffect(
     ILogger<ReportErrorEffect> logger)
     : AsyncEffect<ReportError>
 {
-    public override Task HandleAsync(ReportError action, IStateProvider stateProvider)
+    public override Task HandleAsync(ReportError action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
         logger.LogError(
             action.Exception,

--- a/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/MoviesEffectGroup.cs
+++ b/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/MoviesEffectGroup.cs
@@ -31,7 +31,7 @@ public class MoviesEffectGroup : AsyncEffectGroup
         On<LoadMoviesFailure>(HandleLoadMoviesFailureAsync);
     }
 
-    private async Task HandleLoadMoviesAsync(LoadMovies action, IStateProvider stateProvider)
+    private async Task HandleLoadMoviesAsync(LoadMovies action, IStateProvider stateProvider, CancellationToken cancellationToken)
     {
         try
         {
@@ -46,7 +46,7 @@ public class MoviesEffectGroup : AsyncEffectGroup
         }
     }
 
-    private async Task HandleSearchMoviesAsync(SearchMovies action, IStateProvider stateProvider)
+    private async Task HandleSearchMoviesAsync(SearchMovies action, IStateProvider stateProvider, CancellationToken cancellationToken)
     {
         try
         {
@@ -63,14 +63,14 @@ public class MoviesEffectGroup : AsyncEffectGroup
         }
     }
 
-    private Task HandleLoadMoviesSuccessAsync(LoadMoviesSuccess action, IStateProvider stateProvider)
+    private Task HandleLoadMoviesSuccessAsync(LoadMoviesSuccess action, IStateProvider stateProvider, CancellationToken cancellationToken)
     {
         string message = $"Loaded {action.Movies.Count} movies from the server.";
         ShowSuccessNotification(message);
         return Task.CompletedTask;
     }
 
-    private Task HandleLoadMoviesFailureAsync(LoadMoviesFailure action, IStateProvider stateProvider)
+    private Task HandleLoadMoviesFailureAsync(LoadMoviesFailure action, IStateProvider stateProvider, CancellationToken cancellationToken)
     {
         ShowErrorNotification(action.ErrorMessage);
         return Task.CompletedTask;

--- a/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/OpenAboutDialogEffect.cs
+++ b/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/OpenAboutDialogEffect.cs
@@ -14,7 +14,10 @@ namespace Demo.BlazorWasm.Features.Feedback.Effects;
 public class OpenAboutDialogEffect(IDialogService dialog) : AsyncEffect<OpenAboutDialog>
 {
     /// <inheritdoc />
-    public override async Task HandleAsync(OpenAboutDialog action, IStateProvider stateProvider)
+    public override async Task HandleAsync(
+        OpenAboutDialog action,
+        IStateProvider stateProvider,
+        CancellationToken cancellationToken = default)
     {
         DialogOptions options = new() { CloseOnEscapeKey = true };
 

--- a/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/RetryableMoviesEffect.cs
+++ b/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/RetryableMoviesEffect.cs
@@ -20,7 +20,7 @@ public sealed class RetryableMoviesEffect : AsyncEffect<LoadMovies>
         _logger = logger;
     }
 
-    public override async Task HandleAsync(LoadMovies action, IStateProvider stateProvider)
+    public override async Task HandleAsync(LoadMovies action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/TestErrorEffect.cs
+++ b/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/TestErrorEffect.cs
@@ -12,7 +12,7 @@ namespace Demo.BlazorWasm.Features.Feedback.Effects;
 public class TestErrorEffect : AsyncEffect<TestErrorAction>
 {
     /// <inheritdoc />
-    public override Task HandleAsync(TestErrorAction action, IStateProvider stateProvider)
+    public override Task HandleAsync(TestErrorAction action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
         // Simulate an error by throwing an exception
         throw new ApplicationException(action.ErrorMessage);

--- a/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/TimerEffectGroup.cs
+++ b/src/demo/Demo.BlazorWasm/Features/Feedback/Effects/TimerEffectGroup.cs
@@ -25,14 +25,14 @@ public class TimerEffectGroup : AsyncEffectGroup
         On<Tick>(HandleTickAsync);
     }
 
-    private async Task HandleStartTimerAsync(StartTimer action, IStateProvider stateProvider)
+    private async Task HandleStartTimerAsync(StartTimer action, IStateProvider stateProvider, CancellationToken ct)
     {
         _logger.LogInformation("Starting timer");
 
         // Cancel any existing timer
         StopCurrentTimer();
 
-        _timerCancellationTokenSource = new CancellationTokenSource();
+        _timerCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ct);
         CancellationToken cancellationToken = _timerCancellationTokenSource.Token;
 
         // Start the timer loop
@@ -66,14 +66,14 @@ public class TimerEffectGroup : AsyncEffectGroup
             cancellationToken);
     }
 
-    private Task HandleStopTimerAsync(StopTimer action, IStateProvider stateProvider)
+    private Task HandleStopTimerAsync(StopTimer action, IStateProvider stateProvider, CancellationToken ct)
     {
         _logger.LogInformation("Stopping timer");
         StopCurrentTimer();
         return Task.CompletedTask;
     }
 
-    private Task HandleResetTimerAsync(ResetTimer action, IStateProvider stateProvider)
+    private Task HandleResetTimerAsync(ResetTimer action, IStateProvider stateProvider, CancellationToken ct)
     {
         _logger.LogInformation("Resetting timer");
         StopCurrentTimer();
@@ -81,7 +81,7 @@ public class TimerEffectGroup : AsyncEffectGroup
         return Task.CompletedTask;
     }
 
-    private Task HandleTickAsync(Tick action, IStateProvider stateProvider)
+    private Task HandleTickAsync(Tick action, IStateProvider stateProvider, CancellationToken ct)
     {
         TimerState timerState = stateProvider.GetSlice<TimerState>();
         _logger.LogDebug("Timer tick: {Time}s", timerState.Time);

--- a/src/demo/Demo.ConsoleApp/Counter/CounterEffects.cs
+++ b/src/demo/Demo.ConsoleApp/Counter/CounterEffects.cs
@@ -5,12 +5,15 @@ namespace Demo.ConsoleApp.Counter;
 
 public sealed class DelayedIncrementEffect : AsyncEffect<IncrementAsync>
 {
-    public override async Task HandleAsync(IncrementAsync action, IStateProvider stateProvider)
+    public override async Task HandleAsync(
+        IncrementAsync action,
+        IStateProvider stateProvider,
+        CancellationToken cancellationToken = default)
     {
         AnsiConsole.MarkupLine(
             $"[cyan][[Effect]][/] Starting delayed increment of [yellow]{action.Amount}[/] after [blue]{action.DelayMs}ms[/]...");
 
-        await Task.Delay(action.DelayMs).ConfigureAwait(false);
+        await Task.Delay(action.DelayMs, cancellationToken).ConfigureAwait(false);
 
         AnsiConsole.MarkupLine($"[cyan][[Effect]][/] Delay complete, incrementing by [yellow]{action.Amount}[/]");
         Dispatcher.Increment(action.Amount);
@@ -19,14 +22,14 @@ public sealed class DelayedIncrementEffect : AsyncEffect<IncrementAsync>
 
 public sealed class CounterThresholdEffect : AsyncEffect<Increment>
 {
-    public override async Task HandleAsync(Increment action, IStateProvider stateProvider)
+    public override async Task HandleAsync(Increment action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
         CounterState counterState = stateProvider.GetSlice<CounterState>();
 
         if (counterState.Value >= 10)
         {
             AnsiConsole.MarkupLine("[cyan][[Effect]][/] [bold yellow]Counter reached 10![/] Triggering celebration...");
-            await Task.Delay(500).ConfigureAwait(false);
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
             AnsiConsole.MarkupLine("[cyan][[Effect]][/] [bold green]🎉 Congratulations! You've reached 10![/]");
         }
 

--- a/src/library/Ducky/Abstractions/IAsyncEffect.cs
+++ b/src/library/Ducky/Abstractions/IAsyncEffect.cs
@@ -32,6 +32,7 @@ public interface IAsyncEffect
     /// </summary>
     /// <param name="action">The action to handle.</param>
     /// <param name="stateProvider">The provider for accessing application state.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    Task HandleAsync(object action, IStateProvider stateProvider);
+    Task HandleAsync(object action, IStateProvider stateProvider, CancellationToken cancellationToken = default);
 }

--- a/src/library/Ducky/Middlewares/AsyncEffect/AsyncEffect.cs
+++ b/src/library/Ducky/Middlewares/AsyncEffect/AsyncEffect.cs
@@ -30,9 +30,9 @@ public abstract class AsyncEffect<TAction> : IAsyncEffect
     }
 
     /// <inheritdoc />
-    public Task HandleAsync(object action, IStateProvider stateProvider)
+    public Task HandleAsync(object action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
-        return HandleAsync((TAction)action, stateProvider);
+        return HandleAsync((TAction)action, stateProvider, cancellationToken);
     }
 
     /// <summary>
@@ -40,6 +40,7 @@ public abstract class AsyncEffect<TAction> : IAsyncEffect
     /// </summary>
     /// <param name="action">The action to handle.</param>
     /// <param name="stateProvider">The provider for accessing application state.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    public abstract Task HandleAsync(TAction action, IStateProvider stateProvider);
+    public abstract Task HandleAsync(TAction action, IStateProvider stateProvider, CancellationToken cancellationToken = default);
 }

--- a/src/library/Ducky/Middlewares/AsyncEffect/AsyncEffectGroup.cs
+++ b/src/library/Ducky/Middlewares/AsyncEffect/AsyncEffectGroup.cs
@@ -41,11 +41,11 @@ public abstract class AsyncEffectGroup : IAsyncEffect
     }
 
     /// <inheritdoc />
-    public Task HandleAsync(object action, IStateProvider stateProvider)
+    public Task HandleAsync(object action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
         if (_effects.TryGetValue(action.GetType(), out IAsyncEffect? effect))
         {
-            return effect.HandleAsync(action, stateProvider);
+            return effect.HandleAsync(action, stateProvider, cancellationToken);
         }
 
         return Task.CompletedTask;
@@ -55,26 +55,37 @@ public abstract class AsyncEffectGroup : IAsyncEffect
     /// Registers an effect handler for a specific action type.
     /// </summary>
     /// <typeparam name="TAction">The type of action to handle.</typeparam>
-    /// <param name="handler">The async handler function.</param>
-    protected void On<TAction>(Func<TAction, IStateProvider, Task> handler)
+    /// <param name="handler">The async handler function that accepts a cancellation token.</param>
+    protected void On<TAction>(Func<TAction, IStateProvider, CancellationToken, Task> handler)
     {
         DelegateAsyncEffect<TAction> effect = new(handler, this);
         _effects[typeof(TAction)] = effect;
     }
 
     /// <summary>
+    /// Registers an effect handler for a specific action type (without cancellation token).
+    /// </summary>
+    /// <typeparam name="TAction">The type of action to handle.</typeparam>
+    /// <param name="handler">The async handler function.</param>
+    [Obsolete("Use the overload that accepts CancellationToken for proper cancellation support.")]
+    protected void On<TAction>(Func<TAction, IStateProvider, Task> handler)
+    {
+        On<TAction>((action, stateProvider, _) => handler(action, stateProvider));
+    }
+
+    /// <summary>
     /// Internal effect implementation that delegates to a handler function.
     /// </summary>
     private class DelegateAsyncEffect<TAction>(
-        Func<TAction, IStateProvider, Task> handler,
+        Func<TAction, IStateProvider, CancellationToken, Task> handler,
         AsyncEffectGroup parent)
         : AsyncEffect<TAction>
     {
-        public override Task HandleAsync(TAction action, IStateProvider stateProvider)
+        public override Task HandleAsync(TAction action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
         {
             // Use parent's dispatcher so all effects in the group share the same dispatcher
             Dispatcher = parent.Dispatcher;
-            return handler(action, stateProvider);
+            return handler(action, stateProvider, cancellationToken);
         }
     }
 }

--- a/src/library/Ducky/Middlewares/AsyncEffect/AsyncEffectMiddleware.cs
+++ b/src/library/Ducky/Middlewares/AsyncEffect/AsyncEffectMiddleware.cs
@@ -5,11 +5,13 @@ namespace Ducky.Middlewares.AsyncEffect;
 /// <summary>
 /// Middleware that executes asynchronous effects implementing <see cref="IAsyncEffect"/> when they are dispatched.
 /// </summary>
-public sealed class AsyncEffectMiddleware : MiddlewareBase
+public sealed class AsyncEffectMiddleware : MiddlewareBase, IDisposable
 {
     private readonly IEnumerable<IAsyncEffect> _effects;
     private readonly IStoreEventPublisher _eventPublisher;
+    private CancellationTokenSource _cts = new();
     private IStore? _store;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of <see cref="AsyncEffectMiddleware"/> with the specified dependencies.
@@ -42,11 +44,12 @@ public sealed class AsyncEffectMiddleware : MiddlewareBase
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Always returns true. This middleware should not block actions from reaching
+    /// other middleware and reducers, even if no async effect handles the action.
+    /// </remarks>
     public override bool MayDispatchAction(object action)
     {
-        // Allow dispatch if any effect can handle the action
-        // TODO: Fix this logic to properly check if any effect can handle the action
-        // return _effects.Any(effect => effect.CanHandle(action));
         return true;
     }
 
@@ -56,25 +59,36 @@ public sealed class AsyncEffectMiddleware : MiddlewareBase
         TriggerEffects(action);
     }
 
+    /// <summary>
+    /// Cancels all pending effects and releases resources.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+
     private void TriggerEffects(object action)
     {
-        List<Exception> recordedExceptions = [];
         IAsyncEffect[] effectsToExecute = _effects
             .Where(effect => effect.CanHandle(action))
             .ToArray();
-        List<Task> executedEffects = [];
 
-        Action<Exception> collectExceptions = exception =>
+        if (effectsToExecute.Length == 0)
         {
-            if (exception is AggregateException aggregateException)
-            {
-                recordedExceptions.AddRange(aggregateException.Flatten().InnerExceptions);
-            }
-            else
-            {
-                recordedExceptions.Add(exception);
-            }
-        };
+            return;
+        }
+
+        CancellationToken token = _cts.Token;
+
+        // Track each effect alongside its task for reliable error attribution
+        List<(IAsyncEffect Effect, Task Task)> effectTasks = new(effectsToExecute.Length);
 
         // Execute all effects. Some will execute synchronously and complete immediately,
         // so we need to catch their exceptions in the loop so they don't prevent
@@ -83,37 +97,46 @@ public sealed class AsyncEffectMiddleware : MiddlewareBase
         {
             try
             {
-                executedEffects.Add(effect.HandleAsync(action, _store!));
+                Task task = effect.HandleAsync(action, _store!, token);
+                effectTasks.Add((effect, task));
             }
             catch (Exception exception)
             {
-                collectExceptions(exception);
+                // Synchronous failure — publish immediately with correct attribution
+                _eventPublisher.Publish(new EffectErrorEventArgs(exception, effect.GetType(), action));
             }
         }
 
-        // Fire and forget - handle all async effects concurrently
-        _ = Task.Run(async () =>
+        if (effectTasks.Count == 0)
         {
-            try
-            {
-                await Task.WhenAll(executedEffects).ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                collectExceptions(exception);
-            }
+            return;
+        }
 
-            // Publish all collected exceptions as error events
-            foreach (Exception exception in recordedExceptions)
+        // Fire and forget - handle all async effects concurrently
+        _ = Task.Run(
+            async () =>
             {
-                Type effectType = effectsToExecute
-                    .FirstOrDefault(_ => executedEffects.Any(t => t.Exception?.InnerException == exception))
-                    ?.GetType()
-                    ?? typeof(IAsyncEffect);
+                try
+                {
+                    await Task.WhenAll(effectTasks.Select(et => et.Task)).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Swallow — we inspect individual tasks below for accurate attribution
+                }
 
-                EffectErrorEventArgs errorEventArgs = new(exception, effectType, action);
-                _eventPublisher.Publish(errorEventArgs);
-            }
-        });
+                // Publish errors with correct effect attribution
+                foreach ((IAsyncEffect effect, Task task) in effectTasks)
+                {
+                    if (task is { IsFaulted: true, Exception: not null })
+                    {
+                        foreach (Exception innerEx in task.Exception.Flatten().InnerExceptions)
+                        {
+                            _eventPublisher.Publish(new EffectErrorEventArgs(innerEx, effect.GetType(), action));
+                        }
+                    }
+                }
+            },
+            token);
     }
 }

--- a/src/tests/AppStore.Tests/Counter/CounterEffectsTests.cs
+++ b/src/tests/AppStore.Tests/Counter/CounterEffectsTests.cs
@@ -28,7 +28,7 @@ public sealed class CounterEffectsTests
         A.CallTo(() => stateProvider.GetSlice<CounterState>()).Returns(new CounterState(16));
 
         // Act
-        Task handleTask = _sut.HandleAsync(new Increment(), stateProvider);
+        Task handleTask = _sut.HandleAsync(new Increment(), stateProvider, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromSeconds(10));
         await handleTask;
 
@@ -45,7 +45,7 @@ public sealed class CounterEffectsTests
         A.CallTo(() => stateProvider.GetSlice<CounterState>()).Returns(new CounterState(15));
 
         // Act
-        Task handleTask = _sut.HandleAsync(new Increment(), stateProvider);
+        Task handleTask = _sut.HandleAsync(new Increment(), stateProvider, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromSeconds(10));
         await handleTask;
 

--- a/src/tests/AppStore.Tests/Movies/MoviesEffectGroupTests.cs
+++ b/src/tests/AppStore.Tests/Movies/MoviesEffectGroupTests.cs
@@ -98,7 +98,7 @@ public class MoviesEffectGroupTests
         A.CallTo(() => _moviesService.GetMoviesAsync(1, 5, A<CancellationToken>.Ignored)).Returns(response);
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(() => _dispatcher.Dispatch(
@@ -125,7 +125,7 @@ public class MoviesEffectGroupTests
         A.CallTo(() => _moviesService.GetMoviesAsync(1, 5, A<CancellationToken>.Ignored)).Throws(exception);
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(() => _dispatcher.Dispatch(
@@ -157,7 +157,7 @@ public class MoviesEffectGroupTests
         A.CallTo(() => _moviesService.GetMoviesAsync(1, 5, A<CancellationToken>.Ignored)).Returns(response);
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(() => _dispatcher.Dispatch(
@@ -192,7 +192,7 @@ public class MoviesEffectGroupTests
         A.CallTo(() => _moviesService.GetMoviesAsync(1, 5, A<CancellationToken>.Ignored)).Returns(response);
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(() => _dispatcher.Dispatch(
@@ -213,7 +213,7 @@ public class MoviesEffectGroupTests
         LoadMoviesSuccess action = new(movies, 10);
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(() => _snackbar.Add(
@@ -236,7 +236,7 @@ public class MoviesEffectGroupTests
         LoadMoviesFailure action = new("Failed to load movies");
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(() => _snackbar.Add(
@@ -272,8 +272,8 @@ public class MoviesEffectGroupTests
         A.CallTo(() => _moviesService.GetMoviesAsync(2, 5, A<CancellationToken>.Ignored)).Returns(response);
 
         // Act
-        await _effectGroup.HandleAsync(loadAction, _stateProvider);
-        await _effectGroup.HandleAsync(searchAction, _stateProvider);
+        await _effectGroup.HandleAsync(loadAction, _stateProvider, TestContext.Current.CancellationToken);
+        await _effectGroup.HandleAsync(searchAction, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         // Both handlers should use the same pagination info (page 2)

--- a/src/tests/AppStore.Tests/Timer/TimerEffectGroupTests.cs
+++ b/src/tests/AppStore.Tests/Timer/TimerEffectGroupTests.cs
@@ -49,7 +49,7 @@ public class TimerEffectGroupTests
         A.CallTo(() => _stateProvider.GetSlice<TimerState>()).Returns(timerState);
 
         // Act
-        _ = _effectGroup.HandleAsync(action, _stateProvider);
+        _ = _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Wait a bit for the timer to start
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -71,11 +71,11 @@ public class TimerEffectGroupTests
         A.CallTo(() => _stateProvider.GetSlice<TimerState>()).Returns(timerState);
 
         // Start timer first
-        _ = _effectGroup.HandleAsync(startAction, _stateProvider);
+        _ = _effectGroup.HandleAsync(startAction, _stateProvider, TestContext.Current.CancellationToken);
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
         // Act
-        await _effectGroup.HandleAsync(stopAction, _stateProvider);
+        await _effectGroup.HandleAsync(stopAction, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(_logger).Where(call => call.Method.Name == "Log"
@@ -91,7 +91,7 @@ public class TimerEffectGroupTests
         ResetTimer action = new();
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(_logger).Where(call => call.Method.Name == "Log"
@@ -109,7 +109,7 @@ public class TimerEffectGroupTests
         A.CallTo(() => _stateProvider.GetSlice<TimerState>()).Returns(timerState);
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(_logger).Where(call => call.Method.Name == "Log"
@@ -133,7 +133,7 @@ public class TimerEffectGroupTests
         A.CallTo(() => _stateProvider.GetSlice<TimerState>()).Returns(timerState);
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(() => _dispatcher.Dispatch(
@@ -150,7 +150,7 @@ public class TimerEffectGroupTests
         A.CallTo(() => _stateProvider.GetSlice<TimerState>()).Returns(timerState);
 
         // Act
-        await _effectGroup.HandleAsync(action, _stateProvider);
+        await _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         A.CallTo(() => _dispatcher.Dispatch(
@@ -174,7 +174,7 @@ public class TimerEffectGroupTests
                 atLimitState); // Subsequent checks
 
         // Act
-        _ = _effectGroup.HandleAsync(action, _stateProvider);
+        _ = _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
 
         // Wait for timer to process multiple ticks
         await Task.Delay(3000, TestContext.Current.CancellationToken);
@@ -193,10 +193,10 @@ public class TimerEffectGroupTests
         A.CallTo(() => _stateProvider.GetSlice<TimerState>()).Returns(timerState);
 
         // Act
-        _ = _effectGroup.HandleAsync(action, _stateProvider);
+        _ = _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        _ = _effectGroup.HandleAsync(action, _stateProvider);
+        _ = _effectGroup.HandleAsync(action, _stateProvider, TestContext.Current.CancellationToken);
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
         // Assert
@@ -221,9 +221,9 @@ public class TimerEffectGroupTests
                 stoppedState); // After timer is stopped
 
         // Act - Start timer then immediately stop it
-        _ = _effectGroup.HandleAsync(startAction, _stateProvider);
+        _ = _effectGroup.HandleAsync(startAction, _stateProvider, TestContext.Current.CancellationToken);
         await Task.Delay(100, TestContext.Current.CancellationToken); // Brief delay to let timer start
-        await _effectGroup.HandleAsync(stopAction, _stateProvider);
+        await _effectGroup.HandleAsync(stopAction, _stateProvider, TestContext.Current.CancellationToken);
         await Task.Delay(1500, TestContext.Current.CancellationToken); // Wait to ensure no ticks after stop
 
         // Assert

--- a/src/tests/Ducky.Blazor.Tests/MiddlewareIntegrationTestsSimplified.cs
+++ b/src/tests/Ducky.Blazor.Tests/MiddlewareIntegrationTestsSimplified.cs
@@ -289,7 +289,7 @@ public class MiddlewareIntegrationTestsSimplified : Bunit.BunitContext
 
 public class TestAsyncEffect : AsyncEffect<TestAction>
 {
-    public override Task HandleAsync(TestAction action, IStateProvider stateProvider)
+    public override Task HandleAsync(TestAction action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
     }

--- a/src/tests/Ducky.Tests/Builder/StoreBuilderTests.cs
+++ b/src/tests/Ducky.Tests/Builder/StoreBuilderTests.cs
@@ -155,7 +155,7 @@ public class StoreBuilderTests
 
         public bool CanHandle(object action) => true;
 
-        public Task HandleAsync(object action, IStateProvider stateProvider)
+        public Task HandleAsync(object action, IStateProvider stateProvider, CancellationToken cancellationToken = default)
         {
             LastAction = action;
             return Task.CompletedTask;

--- a/src/tests/Ducky.Tests/Middlewares/AsyncEffectGroupTests.cs
+++ b/src/tests/Ducky.Tests/Middlewares/AsyncEffectGroupTests.cs
@@ -81,7 +81,7 @@ public class AsyncEffectGroupTests
         TestAction1 action = new() { Value = "test" };
 
         // Act
-        await effectGroup.HandleAsync(action, StateProvider);
+        await effectGroup.HandleAsync(action, StateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         effectGroup.HandledActions.ShouldContain(action);
@@ -96,7 +96,7 @@ public class AsyncEffectGroupTests
         UnregisteredAction action = new();
 
         // Act & Assert
-        await Should.NotThrowAsync(() => effectGroup.HandleAsync(action, StateProvider));
+        await Should.NotThrowAsync(() => effectGroup.HandleAsync(action, StateProvider, TestContext.Current.CancellationToken));
         effectGroup.HandledActions.ShouldBeEmpty();
     }
 
@@ -110,8 +110,8 @@ public class AsyncEffectGroupTests
         TestAction2 action2 = new() { Number = 42 };
 
         // Act
-        await effectGroup.HandleAsync(action1, StateProvider);
-        await effectGroup.HandleAsync(action2, StateProvider);
+        await effectGroup.HandleAsync(action1, StateProvider, TestContext.Current.CancellationToken);
+        await effectGroup.HandleAsync(action2, StateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         effectGroup.HandledActions.Count.ShouldBe(2);
@@ -145,8 +145,8 @@ public class AsyncEffectGroupTests
         TestAction2 action2 = new() { Number = 10 };
 
         // Act
-        await effectGroup.HandleAsync(action1, StateProvider);
-        await effectGroup.HandleAsync(action2, StateProvider);
+        await effectGroup.HandleAsync(action1, StateProvider, TestContext.Current.CancellationToken);
+        await effectGroup.HandleAsync(action2, StateProvider, TestContext.Current.CancellationToken);
 
         // Assert
         effectGroup.SharedCounter.ShouldBe(2); // Both handlers increment the shared counter
@@ -172,7 +172,7 @@ public class AsyncEffectGroupTests
             On<TestAction2>(HandleTestAction2Async);
         }
 
-        private Task HandleTestAction1Async(TestAction1 action, IStateProvider stateProvider)
+        private Task HandleTestAction1Async(TestAction1 action, IStateProvider stateProvider, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Handling TestAction1: {Value}", action.Value);
             HandledActions.Add(action);
@@ -180,7 +180,7 @@ public class AsyncEffectGroupTests
             return Task.CompletedTask;
         }
 
-        private Task HandleTestAction2Async(TestAction2 action, IStateProvider stateProvider)
+        private Task HandleTestAction2Async(TestAction2 action, IStateProvider stateProvider, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Handling TestAction2: {Number}", action.Number);
             HandledActions.Add(action);

--- a/src/tests/Ducky.Tests/Middlewares/AsyncEffectMiddlewareTests.cs
+++ b/src/tests/Ducky.Tests/Middlewares/AsyncEffectMiddlewareTests.cs
@@ -127,7 +127,8 @@ public class AsyncEffectMiddlewareTests
         // Wait a short time to ensure async operations complete
         await Task.Delay(50, TestContext.Current.CancellationToken);
 
-        A.CallTo(() => effect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored)).MustNotHaveHappened();
+        A.CallTo(() => effect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
     }
 
     [Fact]
@@ -135,7 +136,7 @@ public class AsyncEffectMiddlewareTests
     {
         IAsyncEffect effect = A.Fake<IAsyncEffect>();
         A.CallTo(() => effect.CanHandle(A<object>.Ignored)).Returns(true);
-        A.CallTo(() => effect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored))
+        A.CallTo(() => effect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
             .Returns(Task.CompletedTask);
         AsyncEffectMiddleware middleware = await CreateInitializedMiddleware(effect);
         TestAction action = new();
@@ -145,7 +146,8 @@ public class AsyncEffectMiddlewareTests
         // Wait a short time to ensure async operations complete
         await Task.Delay(50, TestContext.Current.CancellationToken);
 
-        A.CallTo(() => effect.HandleAsync(action, A<IStateProvider>.That.Matches(sp => sp == _store))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => effect.HandleAsync(action, A<IStateProvider>.That.Matches(sp => sp == _store), A<CancellationToken>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -154,7 +156,7 @@ public class AsyncEffectMiddlewareTests
         IAsyncEffect effect = A.Fake<IAsyncEffect>();
         TestException testException = new();
         A.CallTo(() => effect.CanHandle(A<object>.Ignored)).Returns(true);
-        A.CallTo(() => effect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored))
+        A.CallTo(() => effect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
             .ThrowsAsync(testException);
         AsyncEffectMiddleware middleware = await CreateInitializedMiddleware(effect);
         TestAction action = new();
@@ -187,7 +189,7 @@ public class AsyncEffectMiddlewareTests
     {
         IAsyncEffect slowEffect = A.Fake<IAsyncEffect>();
         A.CallTo(() => slowEffect.CanHandle(A<object>.Ignored)).Returns(true);
-        A.CallTo(() => slowEffect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored))
+        A.CallTo(() => slowEffect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
             .ReturnsLazily(async () => await Task.Delay(200, TestContext.Current.CancellationToken));
 
         AsyncEffectMiddleware middleware = await CreateInitializedMiddleware(slowEffect);
@@ -201,5 +203,131 @@ public class AsyncEffectMiddlewareTests
         // Should complete almost immediately (fire and forget)
         executionTime.TotalMilliseconds
             .ShouldBeLessThan(50, $"AfterReduce took {executionTime.TotalMilliseconds}ms, expected < 50ms");
+    }
+
+    [Fact]
+    public async Task AfterReduce_WithMultipleConcurrentEffects_AttributesExceptionsCorrectly()
+    {
+        // Arrange: two effects handle the same action, only the second one throws
+        IAsyncEffect successEffect = A.Fake<IAsyncEffect>();
+        IAsyncEffect failingEffect = A.Fake<IAsyncEffect>();
+        TestException testException = new();
+
+        A.CallTo(() => successEffect.CanHandle(A<object>.Ignored)).Returns(true);
+        A.CallTo(() => successEffect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(Task.CompletedTask);
+
+        A.CallTo(() => failingEffect.CanHandle(A<object>.Ignored)).Returns(true);
+        A.CallTo(() => failingEffect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
+            .ThrowsAsync(testException);
+
+        AsyncEffectMiddleware middleware = await CreateInitializedMiddleware(successEffect, failingEffect);
+        TestAction action = new();
+
+        // Act
+        middleware.AfterReduce(action);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        // Assert: error attributed to the failing effect, not to IAsyncEffect
+        A.CallTo(() => _eventPublisher.Publish(A<EffectErrorEventArgs>.That.Matches(args =>
+            ReferenceEquals(args.Exception, testException)
+                && args.EffectType == failingEffect.GetType())))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task AfterReduce_WithMultipleFailingEffects_PublishesAllErrorsWithCorrectAttribution()
+    {
+        // Arrange: three effects all throw different exceptions
+        IAsyncEffect effect1 = A.Fake<IAsyncEffect>();
+        IAsyncEffect effect2 = A.Fake<IAsyncEffect>();
+        IAsyncEffect effect3 = A.Fake<IAsyncEffect>();
+        TestException ex1 = new("error1");
+        TestException ex2 = new("error2");
+        TestException ex3 = new("error3");
+
+        A.CallTo(() => effect1.CanHandle(A<object>.Ignored)).Returns(true);
+        A.CallTo(() => effect1.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
+            .ThrowsAsync(ex1);
+
+        A.CallTo(() => effect2.CanHandle(A<object>.Ignored)).Returns(true);
+        A.CallTo(() => effect2.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
+            .ThrowsAsync(ex2);
+
+        A.CallTo(() => effect3.CanHandle(A<object>.Ignored)).Returns(true);
+        A.CallTo(() => effect3.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
+            .ThrowsAsync(ex3);
+
+        AsyncEffectMiddleware middleware = await CreateInitializedMiddleware(effect1, effect2, effect3);
+        TestAction action = new();
+
+        // Act
+        middleware.AfterReduce(action);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        // Assert: each error attributed to the correct effect
+        A.CallTo(() => _eventPublisher.Publish(A<EffectErrorEventArgs>.That.Matches(args =>
+            ReferenceEquals(args.Exception, ex1) && args.EffectType == effect1.GetType())))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _eventPublisher.Publish(A<EffectErrorEventArgs>.That.Matches(args =>
+            ReferenceEquals(args.Exception, ex2) && args.EffectType == effect2.GetType())))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _eventPublisher.Publish(A<EffectErrorEventArgs>.That.Matches(args =>
+            ReferenceEquals(args.Exception, ex3) && args.EffectType == effect3.GetType())))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task Dispose_CancelsPendingEffects()
+    {
+        // Arrange: effect that observes cancellation
+        CancellationToken capturedToken = default;
+        IAsyncEffect effect = A.Fake<IAsyncEffect>();
+        A.CallTo(() => effect.CanHandle(A<object>.Ignored)).Returns(true);
+        A.CallTo(() => effect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
+            .ReturnsLazily(call =>
+            {
+                capturedToken = call.Arguments.Get<CancellationToken>(2)!;
+                return Task.Delay(5000, capturedToken);
+            });
+
+        AsyncEffectMiddleware middleware = await CreateInitializedMiddleware(effect);
+        TestAction action = new();
+
+        // Act
+        middleware.AfterReduce(action);
+        await Task.Delay(50, TestContext.Current.CancellationToken); // Let the effect start
+        middleware.Dispose();
+
+        // Assert
+        capturedToken.IsCancellationRequested.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AfterReduce_PassesCancellationTokenToEffect()
+    {
+        // Arrange
+        CancellationToken capturedToken = default;
+        IAsyncEffect effect = A.Fake<IAsyncEffect>();
+        A.CallTo(() => effect.CanHandle(A<object>.Ignored)).Returns(true);
+        A.CallTo(() => effect.HandleAsync(A<object>.Ignored, A<IStateProvider>.Ignored, A<CancellationToken>.Ignored))
+            .ReturnsLazily(call =>
+            {
+                capturedToken = call.Arguments.Get<CancellationToken>(2)!;
+                return Task.CompletedTask;
+            });
+
+        AsyncEffectMiddleware middleware = await CreateInitializedMiddleware(effect);
+        TestAction action = new();
+
+        // Act
+        middleware.AfterReduce(action);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        // Assert: a non-default cancellation token was passed
+        capturedToken.ShouldNotBe(CancellationToken.None);
+        capturedToken.CanBeCanceled.ShouldBeTrue();
     }
 }

--- a/src/tests/Ducky.Tests/TestModels/TestCounterDuck.cs
+++ b/src/tests/Ducky.Tests/TestModels/TestCounterDuck.cs
@@ -37,7 +37,10 @@ public sealed record TestCounterReducers : SliceReducers<int>
 // Effects
 public sealed class TestIncrementEffect : AsyncEffect<TestIncrementAction>
 {
-    public override async Task HandleAsync(TestIncrementAction action, IStateProvider stateProvider)
+    public override async Task HandleAsync(
+        TestIncrementAction action,
+        IStateProvider stateProvider,
+        CancellationToken cancellationToken = default)
     {
         // if the Value is greater than 15, then reset the counter
         int state = stateProvider.GetSlice<int>();
@@ -46,7 +49,7 @@ public sealed class TestIncrementEffect : AsyncEffect<TestIncrementAction>
             return;
         }
 
-        await Task.Delay(TimeSpan.FromSeconds(3));
+        await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
         Dispatcher.Dispatch(new TestResetAction());
     }
 }


### PR DESCRIPTION
## Summary
- Fix broken error attribution by tracking `(effect, task)` tuples instead of unreliable `FirstOrDefault` matching on `AggregateException` inner exceptions
- Add `CancellationToken` support to `IAsyncEffect.HandleAsync` so effects can respond to store disposal
- Implement `IDisposable` on `AsyncEffectMiddleware` to cancel pending effects via `CancellationTokenSource`
- Resolve `MayDispatchAction` TODO — removed comment, kept `return true` with clarifying remarks (middleware must not block actions from other middleware/reducers)

Closes #186

## Acceptance Criteria
- [x] Effect exceptions are correctly attributed to the originating effect
- [x] `CancellationToken` added to `IAsyncEffect.HandleAsync`
- [x] Store disposal cancels pending effects
- [x] `MayDispatchAction` TODO resolved (implement or remove)
- [x] Unit tests verify error attribution under multiple concurrent effects

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 425 tests pass (173 Ducky.Tests + 92 AppStore.Tests + 92 Ducky.Blazor.Tests + 66 Ducky.Reactive.Tests + 2 Generator.Tests)
- [x] New tests: error attribution with concurrent effects, multiple failing effects, dispose cancels pending effects, cancellation token forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)