### PR TITLE
fix: use dictionary for handler-to-slice pairing in ObservableSlices.Dispose

### DIFF
--- a/src/library/Ducky/ObservableSlices.cs
+++ b/src/library/Ducky/ObservableSlices.cs
@@ -12,7 +12,7 @@ namespace Ducky;
 public sealed class ObservableSlices : IStateProvider, IDisposable
 {
     private readonly Dictionary<string, ISlice> _slices = [];
-    private readonly List<EventHandler> _sliceUpdateHandlers = [];
+    private readonly Dictionary<string, EventHandler> _sliceUpdateHandlers = [];
 
     /// <summary>
     /// Occurs when any slice state changes.
@@ -51,23 +51,20 @@ public sealed class ObservableSlices : IStateProvider, IDisposable
                     newState.GetType(),
                     newState));
         };
-        _sliceUpdateHandlers.Add(handler);
+        _sliceUpdateHandlers[slice.GetKey()] = handler;
         slice.StateUpdated += handler;
     }
 
     /// <inheritdoc />
     public void Dispose()
     {
-        // Unsubscribe all handlers
-        int index = 0;
-        foreach (ISlice slice in _slices.Values)
+        // Unsubscribe all handlers by explicit key pairing
+        foreach ((string key, EventHandler handler) in _sliceUpdateHandlers)
         {
-            if (index < _sliceUpdateHandlers.Count)
+            if (_slices.TryGetValue(key, out ISlice? slice))
             {
-                slice.StateUpdated -= _sliceUpdateHandlers[index];
+                slice.StateUpdated -= handler;
             }
-
-            index++;
         }
 
         _sliceUpdateHandlers.Clear();

--- a/src/tests/Ducky.Tests/Core/ObservableSlicesTests.cs
+++ b/src/tests/Ducky.Tests/Core/ObservableSlicesTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) 2020-2026 Atypical Consulting SRL. All rights reserved.
+// Atypical Consulting SRL licenses this file to you under the Apache-2.0 license.
+// See the LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402, SA1649
+
+namespace Ducky.Tests.Core;
+
+public sealed class ObservableSlicesTests : IDisposable
+{
+    private readonly ObservableSlices _sut = new();
+    private bool _disposed;
+
+    [Fact]
+    public void Dispose_Should_Unsubscribe_All_Handlers_With_Multiple_Slices()
+    {
+        // Arrange
+        SliceA sliceA = new();
+        SliceB sliceB = new();
+        SliceC sliceC = new();
+
+        _sut.AddSlice(sliceA);
+        _sut.AddSlice(sliceB);
+        _sut.AddSlice(sliceC);
+
+        int eventCount = 0;
+        _sut.SliceStateChanged += (_, _) => eventCount++;
+
+        // Verify subscriptions are working before dispose
+        sliceA.OnDispatch(new TestIncrementAction());
+        sliceB.OnDispatch(new TestIncrementAction());
+        sliceC.OnDispatch(new TestIncrementAction());
+        eventCount.ShouldBe(3);
+
+        // Act
+        _sut.Dispose();
+
+        // Reset counter and dispatch again
+        eventCount = 0;
+        sliceA.OnDispatch(new TestIncrementAction());
+        sliceB.OnDispatch(new TestIncrementAction());
+        sliceC.OnDispatch(new TestIncrementAction());
+
+        // Assert - no events should fire after dispose
+        eventCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Dispose_Should_Handle_Empty_Slices()
+    {
+        // Act & Assert - should not throw
+        _sut.Dispose();
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            _sut.Dispose();
+        }
+
+        _disposed = true;
+    }
+}
+
+// Distinct slice types to ensure different dictionary keys
+internal sealed record SliceA : SliceReducers<int>
+{
+    public SliceA()
+    {
+        On<TestIncrementAction>((state, _) => state + 1);
+    }
+
+    public override int GetInitialState() => 0;
+}
+
+internal sealed record SliceB : SliceReducers<long>
+{
+    public SliceB()
+    {
+        On<TestIncrementAction>((state, _) => state + 1);
+    }
+
+    public override long GetInitialState() => 0;
+}
+
+internal sealed record SliceC : SliceReducers<double>
+{
+    public SliceC()
+    {
+        On<TestIncrementAction>((state, _) => state + 1);
+    }
+
+    public override double GetInitialState() => 0;
+}
+
+#pragma warning restore SA1402, SA1649


### PR DESCRIPTION
## Summary
- Replace `List<EventHandler>` with `Dictionary<string, EventHandler>` in `ObservableSlices` to explicitly pair handlers with their slices by key
- Rewrite `Dispose` to look up each handler by slice key instead of relying on fragile index-based correlation
- Add unit tests verifying proper cleanup after multiple slices are registered

Closes #189

## Acceptance Criteria
- [x] Handler-to-slice pairing is explicit (dictionary keyed by slice key)
- [x] Dispose correctly unsubscribes all handlers regardless of iteration order
- [x] Unit test verifies proper cleanup after multiple slices registered

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test src/tests/Ducky.Tests` — 173 tests pass (2 new)
- [x] New tests verify no events fire after Dispose with 3 distinct slice types

🤖 Generated with [Claude Code](https://claude.com/claude-code)