### PR TITLE
fix: require concrete reducer type in AddSlice API

### DIFF
--- a/src/codegen/Ducky.Generator.WebApp/Services/AppStoreCodeGenerator.cs
+++ b/src/codegen/Ducky.Generator.WebApp/Services/AppStoreCodeGenerator.cs
@@ -278,7 +278,7 @@ public class AppStoreCodeGenerator : IAppStoreCodeGenerator
         
         foreach (StateSlice slice in appStore.StateSlices)
         {
-            sb.AppendLine($"                .AddSlice<{slice.Name}State>()");
+            sb.AppendLine($"                .AddSlice<{slice.Name}Reducers>()");
             
             foreach (EffectDefinition effect in slice.Effects)
             {

--- a/src/library/Ducky.Blazor/DuckyBlazorServiceCollectionExtensions.cs
+++ b/src/library/Ducky.Blazor/DuckyBlazorServiceCollectionExtensions.cs
@@ -221,13 +221,13 @@ public class BlazorDuckyBuilder
     }
 
     /// <summary>
-    /// Adds a state slice to the store.
+    /// Adds a concrete slice reducer to the store.
     /// </summary>
-    /// <typeparam name="TState">The state type.</typeparam>
+    /// <typeparam name="TReducer">The concrete <see cref="SliceReducers{TState}"/> implementation type.</typeparam>
     /// <returns>The builder for chaining.</returns>
-    public BlazorDuckyBuilder AddSlice<TState>() where TState : class, IState, new()
+    public BlazorDuckyBuilder AddSlice<TReducer>() where TReducer : class, ISlice
     {
-        _innerBuilder.AddSlice<TState>();
+        _innerBuilder.AddSlice<TReducer>();
         return this;
     }
 

--- a/src/library/Ducky/Builder/DuckyBuilder.cs
+++ b/src/library/Ducky/Builder/DuckyBuilder.cs
@@ -107,11 +107,13 @@ public class DuckyBuilder
     }
 
     /// <summary>
-    /// Adds a state slice to the store.
+    /// Adds a concrete slice reducer to the store.
     /// </summary>
-    public DuckyBuilder AddSlice<TState>() where TState : class, IState, new()
+    /// <typeparam name="TReducer">The concrete <see cref="SliceReducers{TState}"/> implementation type.</typeparam>
+    public DuckyBuilder AddSlice<TReducer>() where TReducer : class, ISlice
     {
-        _services.AddScoped<ISlice<TState>, SliceReducers<TState>>();
+        _services.TryAddScoped<TReducer>();
+        _services.AddScoped<ISlice>(sp => sp.GetRequiredService<TReducer>());
         return this;
     }
 

--- a/src/tests/Ducky.Tests/Builder/StoreBuilderTests.cs
+++ b/src/tests/Ducky.Tests/Builder/StoreBuilderTests.cs
@@ -81,10 +81,29 @@ public class StoreBuilderTests
         ServiceCollection services = [];
 
         // Act
-        services.AddDucky(builder => builder.AddSlice<TestState>());
+        services.AddDucky(builder => builder.AddSlice<TestStateReducers>());
 
         // Assert
-        services.Any(sd => sd.ServiceType == typeof(ISlice<TestState>)).ShouldBeTrue();
+        services.Any(sd => sd.ServiceType == typeof(TestStateReducers)).ShouldBeTrue();
+        services.Any(sd => sd.ServiceType == typeof(ISlice)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StoreBuilder_AddSlice_ShouldResolveAtRuntime()
+    {
+        // Arrange
+        ServiceCollection services = [];
+        services.AddLogging();
+        services.AddDucky(builder => builder.AddSlice<TestStateReducers>());
+
+        // Act
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IEnumerable<ISlice> slices = provider.GetServices<ISlice>();
+
+        // Assert - Should resolve without throwing (unlike the old abstract registration)
+        List<ISlice> sliceList = slices.ToList();
+        sliceList.ShouldNotBeEmpty();
+        sliceList.ShouldContain(s => s is TestStateReducers);
     }
 
     [Fact]
@@ -131,7 +150,7 @@ public class StoreBuilderTests
         {
             builder
                 .UseDefaultMiddlewares()
-                .AddSlice<TestState>()
+                .AddSlice<TestStateReducers>()
                 .AddEffect<TestAsyncEffect>()
                 .AddExceptionHandler<TestExceptionHandler>()
                 .ConfigureStore(options => options.AssemblyNames = ["TestAssembly"]);
@@ -139,7 +158,7 @@ public class StoreBuilderTests
 
         // Verify all registrations
         services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(2); // Default middlewares
-        services.Any(sd => sd.ServiceType == typeof(ISlice<TestState>)).ShouldBeTrue();
+        services.Any(sd => sd.ServiceType == typeof(ISlice)).ShouldBeTrue();
         services.Any(sd => sd.ServiceType == typeof(IAsyncEffect)).ShouldBeTrue();
         services.Any(sd => sd.ServiceType == typeof(IExceptionHandler)).ShouldBeTrue();
     }
@@ -148,6 +167,11 @@ public class StoreBuilderTests
     private class TestMiddleware : MiddlewareBase;
 
     private class TestState : IState;
+
+    private sealed record TestStateReducers : SliceReducers<TestState>
+    {
+        public override TestState GetInitialState() => new();
+    }
 
     private class TestAsyncEffect : IAsyncEffect
     {


### PR DESCRIPTION
## Summary
- `DuckyBuilder.AddSlice<TState>()` registered the abstract `SliceReducers<TState>` class, causing DI container failures at runtime
- Changed API to `AddSlice<TReducer>()` where `TReducer` is the concrete `SliceReducers` implementation
- Updated `BlazorDuckyBuilder.AddSlice` wrapper and code generator to match
- Added integration test verifying runtime DI resolution succeeds

Closes #188

## Acceptance Criteria
- [x] `AddSlice` API correctly registers concrete reducer types
- [x] Runtime DI resolution works without exceptions
- [x] API signature guides developers to provide the correct types
- [x] Unit test verifies slice registration and resolution

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test src/tests/Ducky.Tests` — 172 tests pass
- [x] `dotnet test src/tests/AppStore.Tests` — 92 tests pass
- [x] New `StoreBuilder_AddSlice_ShouldResolveAtRuntime` test verifies end-to-end DI resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)