### PR TITLE
fix: resolve ReactiveEffectMiddleware state/action ordering race condition

### DIFF
--- a/src/library/Ducky.Reactive/GlobalUsings.cs
+++ b/src/library/Ducky.Reactive/GlobalUsings.cs
@@ -4,6 +4,7 @@
 
 // Global using directives
 
+global using System.Collections.Immutable;
 global using System.Reactive;
 global using System.Reactive.Concurrency;
 global using System.Reactive.Disposables;

--- a/src/library/Ducky.Reactive/Middlewares/ReactiveEffects/ReactiveEffectMiddleware.cs
+++ b/src/library/Ducky.Reactive/Middlewares/ReactiveEffects/ReactiveEffectMiddleware.cs
@@ -34,7 +34,8 @@ public sealed class ReactiveEffectMiddleware : MiddlewareBase
 
         _effects = effects;
         _eventPublisher = eventPublisher;
-        _stateProvider = new BehaviorSubject<IStateProvider>(null!);
+        _stateProvider = new BehaviorSubject<IStateProvider>(
+            new StateSnapshot(ImmutableSortedDictionary<string, object>.Empty));
     }
 
     /// <inheritdoc />
@@ -43,8 +44,8 @@ public sealed class ReactiveEffectMiddleware : MiddlewareBase
         _dispatcher = dispatcher;
         _store = store;
 
-        // Initialize state provider
-        _stateProvider.OnNext(store);
+        // Initialize state provider with a snapshot of the current state
+        _stateProvider.OnNext(new StateSnapshot(store.GetStateDictionary()));
 
         // Subscribe to all effects
         foreach (ReactiveEffect effect in _effects)
@@ -82,10 +83,10 @@ public sealed class ReactiveEffectMiddleware : MiddlewareBase
     /// <inheritdoc />
     public override void AfterReduce(object action)
     {
-        // Update state after reduction
+        // Snapshot state after reduction to ensure effects see consistent state
         if (_store is not null)
         {
-            _stateProvider.OnNext(_store);
+            _stateProvider.OnNext(new StateSnapshot(_store.GetStateDictionary()));
         }
 
         // Stream the action to all effects

--- a/src/library/Ducky.Reactive/Middlewares/ReactiveEffects/StateSnapshot.cs
+++ b/src/library/Ducky.Reactive/Middlewares/ReactiveEffects/StateSnapshot.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2020-2026 Atypical Consulting SRL. All rights reserved.
+// Atypical Consulting SRL licenses this file to you under the Apache-2.0 license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace Ducky.Reactive.Middlewares.ReactiveEffects;
+
+/// <summary>
+/// An immutable point-in-time snapshot of application state.
+/// Used to ensure reactive effects see consistent state corresponding to a specific action.
+/// </summary>
+internal sealed class StateSnapshot : IStateProvider
+{
+    private readonly ImmutableSortedDictionary<string, object> _state;
+
+    public StateSnapshot(ImmutableSortedDictionary<string, object> state)
+    {
+        _state = state;
+    }
+
+    public TState GetSlice<TState>()
+    {
+        string? key = _state.Keys.FirstOrDefault(k => _state[k] is TState);
+        if (key is not null)
+        {
+            return (TState)_state[key];
+        }
+
+        throw new InvalidOperationException($"Slice of type {typeof(TState).Name} not found in state snapshot.");
+    }
+
+    public TState GetSliceByKey<TState>(string key)
+    {
+        if (_state.TryGetValue(key, out object? value) && value is TState state)
+        {
+            return state;
+        }
+
+        throw new KeyNotFoundException($"Slice with key '{key}' not found in state snapshot.");
+    }
+
+    public bool TryGetSlice<TState>(out TState? state)
+    {
+        string? key = _state.Keys.FirstOrDefault(k => _state[k] is TState);
+        if (key is not null)
+        {
+            state = (TState)_state[key];
+            return true;
+        }
+
+        state = default;
+        return false;
+    }
+
+    public bool HasSlice<TState>()
+    {
+        return _state.Values.Any(v => v is TState);
+    }
+
+    public bool HasSliceByKey(string key)
+    {
+        return _state.ContainsKey(key);
+    }
+
+    public IReadOnlyCollection<string> GetSliceKeys()
+    {
+        return _state.Keys.ToList();
+    }
+
+    public IReadOnlyDictionary<string, object> GetAllSlices()
+    {
+        return _state;
+    }
+
+    public ImmutableSortedDictionary<string, object> GetStateDictionary()
+    {
+        return _state;
+    }
+
+    public ImmutableSortedSet<string> GetKeys()
+    {
+        return _state.Keys.ToImmutableSortedSet();
+    }
+}

--- a/src/tests/Ducky.Reactive.Tests/GlobalUsings.cs
+++ b/src/tests/Ducky.Reactive.Tests/GlobalUsings.cs
@@ -4,6 +4,7 @@
 
 // Global using directives for tests
 
+global using System.Collections.Immutable;
 global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using System.Reactive.Subjects;

--- a/src/tests/Ducky.Reactive.Tests/ReactiveEffectIntegrationTests.cs
+++ b/src/tests/Ducky.Reactive.Tests/ReactiveEffectIntegrationTests.cs
@@ -24,6 +24,10 @@ public class ReactiveEffectIntegrationTests : ReactiveTest
         _stateProviderMock = A.Fake<IStateProvider>();
 
         // Note: Can't mock CurrentState() as it's an extension method
+
+        // Default: return empty state dictionary for snapshot creation
+        A.CallTo(() => _storeMock.GetStateDictionary())
+            .Returns(ImmutableSortedDictionary<string, object>.Empty);
     }
 
     [Fact]
@@ -119,9 +123,10 @@ public class ReactiveEffectIntegrationTests : ReactiveTest
         List<ReactiveEffect> effects = [stateEffect];
         ReactiveEffectMiddleware middleware = new(effects, _eventPublisherMock);
 
-        // Setup initial state
+        // Setup initial state with GetStateDictionary for snapshot creation
         CounterState initialState = new(0);
-        A.CallTo(() => _stateProviderMock.GetSlice<CounterState>()).Returns(initialState);
+        A.CallTo(() => _storeMock.GetStateDictionary())
+            .Returns(ImmutableSortedDictionary<string, object>.Empty.Add("counter", initialState));
 
         await middleware.InitializeAsync(_dispatcherMock, _storeMock);
 
@@ -129,8 +134,8 @@ public class ReactiveEffectIntegrationTests : ReactiveTest
         for (int i = 1; i <= 12; i++)
         {
             CounterState newState = new(i);
-            A.CallTo(() => _stateProviderMock.GetSlice<CounterState>()).Returns(newState);
-            A.CallTo(() => _storeMock.GetSlice<CounterState>()).Returns(newState);
+            A.CallTo(() => _storeMock.GetStateDictionary())
+                .Returns(ImmutableSortedDictionary<string, object>.Empty.Add("counter", newState));
 
             middleware.AfterReduce(new { Type = "INCREMENT" });
         }
@@ -256,10 +261,10 @@ public class ReactiveEffectIntegrationTests : ReactiveTest
         List<ReactiveEffect> effects = [timerEffect, stateEffect];
         ReactiveEffectMiddleware middleware = new(effects, _eventPublisherMock);
 
-        // Setup state
+        // Setup state with GetStateDictionary for snapshot creation
         CounterState state = new(5);
-        A.CallTo(() => _stateProviderMock.GetSlice<CounterState>()).Returns(state);
-        A.CallTo(() => _storeMock.GetSlice<CounterState>()).Returns(state);
+        A.CallTo(() => _storeMock.GetStateDictionary())
+            .Returns(ImmutableSortedDictionary<string, object>.Empty.Add("counter", state));
 
         await middleware.InitializeAsync(_dispatcherMock, _storeMock);
 

--- a/src/tests/Ducky.Reactive.Tests/ReactiveEffectMiddlewareTests.cs
+++ b/src/tests/Ducky.Reactive.Tests/ReactiveEffectMiddlewareTests.cs
@@ -22,6 +22,10 @@ public class ReactiveEffectMiddlewareTests
         A.CallTo(() => _storeMock.GetSlice<object>()).Returns(_stateProviderMock.GetSlice<object>());
         A.CallTo(() => _storeMock.GetSliceByKey<object>(A<string>.Ignored))
             .ReturnsLazily(call => _stateProviderMock.GetSliceByKey<object>(call.Arguments[0] as string ?? string.Empty));
+
+        // Default: return empty state dictionary for snapshot creation
+        A.CallTo(() => _storeMock.GetStateDictionary())
+            .Returns(ImmutableSortedDictionary<string, object>.Empty);
     }
 
     [Fact]
@@ -235,5 +239,154 @@ public class ReactiveEffectMiddlewareTests
             stateProvider.Subscribe(state => ReceivedStates.Add(state));
             return Observable.Empty<object>();
         }
+    }
+
+    private class StateActionPairingEffect : ReactiveEffect
+    {
+        public List<(object Action, IStateProvider State)> Pairs { get; } = [];
+
+        public override IObservable<object> Handle(IObservable<object> actions, IObservable<IStateProvider> stateProvider)
+        {
+            actions.WithLatestFrom(stateProvider, (a, s) => (a, s))
+                .Subscribe(pair => Pairs.Add(pair));
+            return Observable.Empty<object>();
+        }
+    }
+
+    [Fact]
+    public async Task InitializeAsync_BehaviorSubjectInitialValue_ShouldNotBeNull()
+    {
+        // Arrange
+        StateTrackingReactiveEffect effect = new();
+        List<ReactiveEffect> effects = [effect];
+        ReactiveEffectMiddleware middleware = new(effects, _eventPublisherMock);
+
+        // Act
+        await middleware.InitializeAsync(_dispatcherMock, _storeMock);
+
+        // Wait for observable to process
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+
+        // Assert - the first state received (from BehaviorSubject replay) should not be null
+        effect.ReceivedStates.ShouldNotBeEmpty();
+        effect.ReceivedStates.All(s => s is not null).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AfterReduce_RapidDispatch_ShouldSnapshotStatePerAction()
+    {
+        // Arrange
+        StateActionPairingEffect effect = new();
+        List<ReactiveEffect> effects = [effect];
+        ReactiveEffectMiddleware middleware = new(effects, _eventPublisherMock);
+
+        ImmutableSortedDictionary<string, object> state1 = ImmutableSortedDictionary<string, object>.Empty.Add("counter", 1);
+        ImmutableSortedDictionary<string, object> state2 = ImmutableSortedDictionary<string, object>.Empty.Add("counter", 2);
+        ImmutableSortedDictionary<string, object> state3 = ImmutableSortedDictionary<string, object>.Empty.Add("counter", 3);
+
+        Queue<ImmutableSortedDictionary<string, object>> stateQueue = new();
+        stateQueue.Enqueue(state1);
+        stateQueue.Enqueue(state2);
+        stateQueue.Enqueue(state3);
+
+        await middleware.InitializeAsync(_dispatcherMock, _storeMock);
+
+        // Configure store to return different state dictionaries on each call
+        A.CallTo(() => _storeMock.GetStateDictionary())
+            .ReturnsLazily(() => stateQueue.Dequeue());
+
+        object action1 = new { Type = "ACTION_1" };
+        object action2 = new { Type = "ACTION_2" };
+        object action3 = new { Type = "ACTION_3" };
+
+        // Act - rapid dispatch of 3 actions
+        middleware.AfterReduce(action1);
+        middleware.AfterReduce(action2);
+        middleware.AfterReduce(action3);
+
+        // Wait for observables to process
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        // Assert - each action should be paired with its corresponding state snapshot
+        effect.Pairs.Count.ShouldBe(3);
+
+        effect.Pairs[0].Action.ShouldBe(action1);
+        effect.Pairs[0].State.GetStateDictionary()["counter"].ShouldBe(1);
+
+        effect.Pairs[1].Action.ShouldBe(action2);
+        effect.Pairs[1].State.GetStateDictionary()["counter"].ShouldBe(2);
+
+        effect.Pairs[2].Action.ShouldBe(action3);
+        effect.Pairs[2].State.GetStateDictionary()["counter"].ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task AfterReduce_SnapshotImmutability_ShouldPreserveOldState()
+    {
+        // Arrange
+        StateTrackingReactiveEffect effect = new();
+        List<ReactiveEffect> effects = [effect];
+        ReactiveEffectMiddleware middleware = new(effects, _eventPublisherMock);
+
+        ImmutableSortedDictionary<string, object> initialState =
+            ImmutableSortedDictionary<string, object>.Empty.Add("value", "first");
+
+        A.CallTo(() => _storeMock.GetStateDictionary()).Returns(initialState);
+        await middleware.InitializeAsync(_dispatcherMock, _storeMock);
+
+        // Act - dispatch first action, capture the snapshot
+        middleware.AfterReduce(new { Type = "ACTION_1" });
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+
+        IStateProvider firstSnapshot = effect.ReceivedStates.Last();
+
+        // Now change what the store returns and dispatch again
+        ImmutableSortedDictionary<string, object> updatedState =
+            ImmutableSortedDictionary<string, object>.Empty.Add("value", "second");
+        A.CallTo(() => _storeMock.GetStateDictionary()).Returns(updatedState);
+
+        middleware.AfterReduce(new { Type = "ACTION_2" });
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+
+        // Assert - first snapshot should still have the old value
+        firstSnapshot.GetStateDictionary()["value"].ShouldBe("first");
+
+        // Latest snapshot should have the new value
+        IStateProvider secondSnapshot = effect.ReceivedStates.Last();
+        secondSnapshot.GetStateDictionary()["value"].ShouldBe("second");
+    }
+
+    [Fact]
+    public async Task AfterReduce_EffectSeesCorrectStatePairedWithAction()
+    {
+        // Arrange
+        StateActionPairingEffect effect = new();
+        List<ReactiveEffect> effects = [effect];
+        ReactiveEffectMiddleware middleware = new(effects, _eventPublisherMock);
+
+        ImmutableSortedDictionary<string, object> stateA =
+            ImmutableSortedDictionary<string, object>.Empty.Add("phase", "A");
+        ImmutableSortedDictionary<string, object> stateB =
+            ImmutableSortedDictionary<string, object>.Empty.Add("phase", "B");
+
+        await middleware.InitializeAsync(_dispatcherMock, _storeMock);
+
+        // Act
+        A.CallTo(() => _storeMock.GetStateDictionary()).Returns(stateA);
+        object actionA = new { Type = "DO_A" };
+        middleware.AfterReduce(actionA);
+
+        A.CallTo(() => _storeMock.GetStateDictionary()).Returns(stateB);
+        object actionB = new { Type = "DO_B" };
+        middleware.AfterReduce(actionB);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        // Assert
+        effect.Pairs.Count.ShouldBe(2);
+        effect.Pairs[0].Action.ShouldBe(actionA);
+        effect.Pairs[0].State.GetStateDictionary()["phase"].ShouldBe("A");
+        effect.Pairs[1].Action.ShouldBe(actionB);
+        effect.Pairs[1].State.GetStateDictionary()["phase"].ShouldBe("B");
     }
 }


### PR DESCRIPTION
## Summary
- Replace mutable `IStore` reference in `BehaviorSubject<IStateProvider>` with immutable `StateSnapshot` instances that capture state at the time of each action
- Initialize `BehaviorSubject` with empty `StateSnapshot` instead of `null!` to prevent NullReferenceException for early subscribers
- Create `StateSnapshot` class implementing `IStateProvider` backed by `ImmutableSortedDictionary<string, object>`

Closes #190

## Acceptance Criteria
- [x] State snapshot corresponds to the action that triggered the effect
- [x] BehaviorSubject initialized with valid (non-null) state provider
- [x] Race conditions under rapid action dispatch are handled
- [x] Unit tests verify state/action consistency in reactive effects

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test src/tests/Ducky.Reactive.Tests` — 70 tests pass (4 new + 66 existing)
- [x] `dotnet test src/tests/Ducky.Tests` — 171 tests pass
- [x] `dotnet test src/tests/AppStore.Tests` — 92 tests pass
- [x] New test: `BehaviorSubject_InitialValue_ShouldNotBeNull` verifies non-null initial state
- [x] New test: `RapidDispatch_ShouldSnapshotStatePerAction` verifies each action gets its own snapshot
- [x] New test: `SnapshotImmutability_ShouldPreserveOldState` verifies snapshots don't mutate
- [x] New test: `EffectSeesCorrectStatePairedWithAction` verifies state/action pairing via WithLatestFrom

🤖 Generated with [Claude Code](https://claude.com/claude-code)