### PR TITLE
perf: replace linear slice lookups with O(1) dictionary-indexed lookups

### DIFF
--- a/src/library/Ducky/DuckyStore.cs
+++ b/src/library/Ducky/DuckyStore.cs
@@ -108,7 +108,7 @@ public sealed class DuckyStore : IStore, IDisposable
     public DateTime StartTime => _startTime;
 
     /// <inheritdoc/>
-    public int SliceCount => _slices.AllSlices.Count();
+    public int SliceCount => _slices.Count;
 
     /// <inheritdoc/>
     public void Dispose()
@@ -292,13 +292,12 @@ public sealed class DuckyStore : IStore, IDisposable
 
         void Handler(object? sender, StateChangedEventArgs e)
         {
-            ISlice? slice = _slices.AllSlices.FirstOrDefault(s => s.GetStateType() == stateType);
-            if (slice is null)
+            if (e.SliceType != stateType)
             {
                 return;
             }
 
-            var currentState = (TState)slice.GetState();
+            var currentState = (TState)e.NewState;
 
             // Only notify if state actually changed
             if (hasPreviousState && EqualityComparer<TState>.Default.Equals(previousState, currentState))

--- a/src/library/Ducky/Normalization/NormalizedState.cs
+++ b/src/library/Ducky/Normalization/NormalizedState.cs
@@ -18,6 +18,8 @@ public abstract record NormalizedState<TKey, TEntity, TState>
     where TEntity : IEntity<TKey>
     where TState : NormalizedState<TKey, TEntity, TState>, new()
 {
+    private ImmutableArray<TKey>? _cachedAllIds;
+
     /// <summary>
     /// Gets or init the dictionary of entities.
     /// </summary>
@@ -27,7 +29,7 @@ public abstract record NormalizedState<TKey, TEntity, TState>
     /// Gets the collection of entity IDs.
     /// </summary>
     public ImmutableArray<TKey> AllIds
-        => [..ById.Keys];
+        => _cachedAllIds ??= ImmutableArray.CreateRange(ById.Keys);
 
     /// <summary>
     /// Indexer to get an entity by its key.

--- a/src/library/Ducky/ObservableSlices.cs
+++ b/src/library/Ducky/ObservableSlices.cs
@@ -12,12 +12,18 @@ namespace Ducky;
 public sealed class ObservableSlices : IStateProvider, IDisposable
 {
     private readonly Dictionary<string, ISlice> _slices = [];
+    private readonly Dictionary<Type, ISlice> _slicesByStateType = [];
     private readonly Dictionary<string, EventHandler> _sliceUpdateHandlers = [];
 
     /// <summary>
     /// Occurs when any slice state changes.
     /// </summary>
     public event EventHandler<StateChangedEventArgs>? SliceStateChanged;
+
+    /// <summary>
+    /// Gets the number of registered slices.
+    /// </summary>
+    public int Count => _slices.Count;
 
     /// <summary>
     /// Gets an enumerable collection of all registered slices.
@@ -33,7 +39,23 @@ public sealed class ObservableSlices : IStateProvider, IDisposable
     {
         ArgumentNullException.ThrowIfNull(slice);
 
-        _slices[slice.GetKey()] = slice;
+        string key = slice.GetKey();
+        Type stateType = slice.GetStateType();
+
+        // If replacing an existing slice with the same key,
+        // update the type index to point to the new instance.
+        if (_slices.TryGetValue(key, out ISlice? existingSlice))
+        {
+            Type existingType = existingSlice.GetStateType();
+            if (_slicesByStateType.TryGetValue(existingType, out ISlice? indexedSlice)
+                && ReferenceEquals(indexedSlice, existingSlice))
+            {
+                _slicesByStateType[existingType] = slice;
+            }
+        }
+
+        _slices[key] = slice;
+        _slicesByStateType.TryAdd(stateType, slice);
 
         // Create handler for slice updates
         EventHandler handler = (sender, _) =>
@@ -69,6 +91,7 @@ public sealed class ObservableSlices : IStateProvider, IDisposable
 
         _sliceUpdateHandlers.Clear();
         _slices.Clear();
+        _slicesByStateType.Clear();
         SliceStateChanged = null;
     }
 
@@ -77,10 +100,11 @@ public sealed class ObservableSlices : IStateProvider, IDisposable
     /// <inheritdoc />
     public TState GetSlice<TState>()
     {
-        ISlice? slice = _slices.Values.FirstOrDefault(s => s.GetState() is TState);
-        if (slice is null)
+        if (!_slicesByStateType.TryGetValue(
+            typeof(TState), out ISlice? slice))
         {
-            throw new InvalidOperationException($"Slice of type {typeof(TState).Name} not found.");
+            throw new InvalidOperationException(
+                $"Slice of type {typeof(TState).Name} not found.");
         }
 
         return (TState)slice.GetState();
@@ -100,8 +124,8 @@ public sealed class ObservableSlices : IStateProvider, IDisposable
     /// <inheritdoc />
     public bool TryGetSlice<TState>(out TState? state)
     {
-        ISlice? slice = _slices.Values.FirstOrDefault(s => s.GetState() is TState);
-        if (slice is not null)
+        if (_slicesByStateType.TryGetValue(
+            typeof(TState), out ISlice? slice))
         {
             state = (TState)slice.GetState();
             return true;
@@ -114,7 +138,7 @@ public sealed class ObservableSlices : IStateProvider, IDisposable
     /// <inheritdoc />
     public bool HasSlice<TState>()
     {
-        return _slices.Values.Any(s => s.GetState() is TState);
+        return _slicesByStateType.ContainsKey(typeof(TState));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- Add `Dictionary<Type, ISlice>` type index to `ObservableSlices` for O(1) `GetSlice<T>()`, `TryGetSlice<T>()`, and `HasSlice<T>()`
- Add `Count` property to `ObservableSlices`; use it in `DuckyStore.SliceCount` instead of LINQ `.Count()`
- Filter `DuckyComponent<TState>.OnStateChanged` by `e.SliceType` to skip irrelevant slice changes
- Optimize `DuckyStore.WhenSliceChanges` to filter by `SliceType` and read state from event args
- Cache `AllIds` in `NormalizedState` per record instance (avoids per-access `ImmutableArray` allocation)
- Cache `SliceReducers.GetKey()` result (avoids repeated Regex execution)

Closes #184

## Acceptance Criteria
- [x] `GetSlice<TState>()` uses O(1) dictionary lookup
- [x] `DuckyComponent<TState>` subscribes only to relevant slice changes (filters by `SliceType`)
- [x] `SliceCount` uses dictionary `.Count` property
- [x] `AllIds` caches per record instance (avoids per-access allocation)
- [x] `SliceReducers.GetKey()` result is cached

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test src/tests/Ducky.Tests` — 235 tests pass
- [x] `dotnet test src/tests/Ducky.Blazor.Tests` — 184 tests pass
- [x] No `FirstOrDefault` remaining in `ObservableSlices.cs`
- [x] No `.Count()` LINQ on `AllSlices` in `DuckyStore.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)