### PR TITLE
refactor: unify async and reactive effect registration APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,17 +136,47 @@ For collections, use `NormalizedState<TKey, TEntity, TState>` to maintain relati
 public record TodoState(NormalizedState<Guid, TodoItem> Items);
 ```
 
-#### Reactive Effects
-Handle side effects reactively using R3 observables:
+#### Effects: Async vs Reactive
+
+Ducky provides two unified effect systems registered through the same `DuckyBuilder` API:
+
+**When to use Async Effects** (`AsyncEffect<TAction>`, `AsyncEffectGroup`):
+- Simple request/response patterns (API calls, data fetching)
+- One-shot side effects (delayed actions, notifications)
+- Effects that handle a single action type
+
+**When to use Reactive Effects** (`ReactiveEffect`):
+- Stream-based patterns (debounce, throttle, retry)
+- State monitoring with deduplication
+- Complex event coordination across multiple action types
+- Timer-based logic, polling, observable composition
+
+**Registration (unified API):**
+```csharp
+services.AddDucky(builder => builder
+    .AddEffect<MyApiEffect>()                  // async effect
+    .AddEffectGroup<MoviesEffectGroup>()       // async effect group
+    .AddReactiveEffect<DebouncedSearchEffect>() // reactive effect
+    .AddReactiveEffects(fx => fx               // multiple reactive effects
+        .Add<TimerEffect>()
+        .Add<StateMonitorEffect>()
+        .WithLoggingMonitor())
+);
+```
+
+**Reactive effect example:**
 ```csharp
 public class TimerEffect : ReactiveEffect
 {
-    public override Observable<object> Handle(Observable<object> actions, Observable<IRootState> rootState)
+    public override IObservable<object> Handle(
+        IObservable<object> actions,
+        IObservable<IStateProvider> stateProvider)
     {
         return actions
             .OfActionType<StartTimer>()
-            .SwitchSelect(_ => Observable.Interval(TimeSpan.FromSeconds(1), TimeProvider)
+            .SelectMany(_ => Observable.Interval(TimeSpan.FromSeconds(1))
                 .Select(_ => new Tick())
+                .Cast<object>()
                 .TakeUntil(actions.OfActionType<StopTimer>()));
     }
 }

--- a/src/demo/Demo.BlazorWasm/AppStore/Counter/CounterMilestoneReactiveEffect.cs
+++ b/src/demo/Demo.BlazorWasm/AppStore/Counter/CounterMilestoneReactiveEffect.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2020-2026 Atypical Consulting SRL. All rights reserved.
+// Atypical Consulting SRL licenses this file to you under the Apache-2.0 license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using Ducky.Reactive;
+using Ducky.Reactive.Middlewares.ReactiveEffects;
+
+namespace Demo.BlazorWasm.AppStore;
+
+/// <summary>
+/// A reactive effect that monitors counter milestones using observable streams.
+/// Demonstrates the recommended reactive effect pattern for stream-based scenarios
+/// like debouncing, throttling, and state monitoring.
+/// </summary>
+/// <remarks>
+/// Use reactive effects when you need:
+/// - Stream composition (debounce, throttle, merge, combine)
+/// - State monitoring with deduplication
+/// - Complex event coordination across multiple action types
+///
+/// Use async effects for simpler patterns like API calls or one-shot side effects.
+/// </remarks>
+public class CounterMilestoneReactiveEffect : ReactiveEffect
+{
+    public override IObservable<object> Handle(
+        IObservable<object> actions,
+        IObservable<IStateProvider> stateProvider)
+    {
+        // Monitor counter state and emit a SetValue action when a milestone is reached.
+        // This demonstrates state monitoring with DistinctUntilChanged to avoid duplicate emissions.
+        return stateProvider
+            .Select(sp => sp.GetSlice<CounterState>())
+            .DistinctUntilChanged(state => state.Value)
+            .Where(state => state.Value > 0 && state.Value % 100 == 0)
+            .Select(state => (object)new CounterMilestoneReached(state.Value));
+    }
+}
+
+/// <summary>
+/// Action dispatched when the counter reaches a milestone (multiple of 100).
+/// </summary>
+[DuckyAction]
+public record CounterMilestoneReached(int MilestoneValue);

--- a/src/library/Ducky.Blazor/DuckyBlazorServiceCollectionExtensions.cs
+++ b/src/library/Ducky.Blazor/DuckyBlazorServiceCollectionExtensions.cs
@@ -10,6 +10,8 @@ using Ducky.Blazor.Middlewares.Persistence;
 using Ducky.Blazor.Services;
 using Ducky.Builder;
 using Ducky.Pipeline;
+using Ducky.Reactive;
+using Ducky.Reactive.Middlewares.ReactiveEffects;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Reflection;
@@ -239,6 +241,28 @@ public class BlazorDuckyBuilder
     public BlazorDuckyBuilder AddEffect<TEffect>() where TEffect : class, IAsyncEffect
     {
         _innerBuilder.AddEffect<TEffect>();
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a reactive effect.
+    /// </summary>
+    /// <typeparam name="TEffect">The reactive effect type.</typeparam>
+    /// <returns>The builder for chaining.</returns>
+    public BlazorDuckyBuilder AddReactiveEffect<TEffect>() where TEffect : ReactiveEffect
+    {
+        _innerBuilder.AddReactiveEffect<TEffect>();
+        return this;
+    }
+
+    /// <summary>
+    /// Adds reactive effects with configuration.
+    /// </summary>
+    /// <param name="configure">Action to configure reactive effects.</param>
+    /// <returns>The builder for chaining.</returns>
+    public BlazorDuckyBuilder AddReactiveEffects(Action<ReactiveEffectsBuilder> configure)
+    {
+        _innerBuilder.AddReactiveEffects(configure);
         return this;
     }
 

--- a/src/library/Ducky/Builder/DuckyBuilder.cs
+++ b/src/library/Ducky/Builder/DuckyBuilder.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Ducky.Middlewares.AsyncEffect;
 using Ducky.Middlewares.CorrelationId;
 using Ducky.Pipeline;
+using Ducky.Reactive;
 using System.Reflection;
 
 namespace Ducky.Builder;
@@ -22,6 +23,11 @@ public class DuckyBuilder
     private readonly HashSet<Assembly> _assembliesToScan = [];
     private bool _defaultMiddlewaresAdded;
     private Action<DuckyOptions>? _configureOptions;
+
+    /// <summary>
+    /// Gets the service collection for internal use by extension methods within the Ducky library.
+    /// </summary>
+    internal IServiceCollection Services => _services;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DuckyBuilder"/> class.
@@ -41,7 +47,7 @@ public class DuckyBuilder
     }
 
     /// <summary>
-    /// Uses the default middleware configuration (CorrelationId, AsyncEffect).
+    /// Uses the default middleware configuration (CorrelationId, AsyncEffect, ReactiveEffect).
     /// </summary>
     public DuckyBuilder UseDefaultMiddlewares()
     {
@@ -53,6 +59,7 @@ public class DuckyBuilder
         _defaultMiddlewaresAdded = true;
         AddMiddleware<CorrelationIdMiddleware>();
         AddMiddleware<AsyncEffectMiddleware>();
+        AddMiddleware<ReactiveEffectMiddleware>();
         return this;
     }
 
@@ -216,6 +223,7 @@ public class DuckyBuilder
         {
             ScanAndRegister<ISlice>(assembly);
             ScanAndRegister<IAsyncEffect>(assembly);
+            ScanAndRegister<ReactiveEffect>(assembly);
         }
 
         // Configure store
@@ -232,6 +240,13 @@ public class DuckyBuilder
             {
                 throw new MissingMiddlewareException(
                     "AsyncEffectMiddleware is required when using async effects. Add it with builder.AddMiddleware<AsyncEffectMiddleware>()");
+            }
+
+            IEnumerable<ReactiveEffect> reactiveEffects = sp.GetServices<ReactiveEffect>();
+            if (reactiveEffects.Any() && !_middlewareTypes.Contains(typeof(ReactiveEffectMiddleware)))
+            {
+                throw new MissingMiddlewareException(
+                    "ReactiveEffectMiddleware is required when using reactive effects. Add it with builder.AddMiddleware<ReactiveEffectMiddleware>() or builder.AddReactiveEffects().");
             }
 
             // Create pipeline

--- a/src/library/Ducky/Builder/MiddlewareOrderValidator.cs
+++ b/src/library/Ducky/Builder/MiddlewareOrderValidator.cs
@@ -4,6 +4,7 @@
 
 using Ducky.Middlewares.AsyncEffect;
 using Ducky.Middlewares.CorrelationId;
+using Ducky.Reactive;
 
 namespace Ducky.Builder;
 
@@ -17,7 +18,7 @@ internal static class MiddlewareOrderValidator
         [typeof(CorrelationIdMiddleware)] = new MiddlewareOrderRule
         {
             Priority = 100,
-            ShouldComeBefore = new HashSet<Type> { typeof(AsyncEffectMiddleware) },
+            ShouldComeBefore = new HashSet<Type> { typeof(AsyncEffectMiddleware), typeof(ReactiveEffectMiddleware) },
             Reason = "CorrelationId should be set early to track actions through the entire pipeline"
         },
         [typeof(AsyncEffectMiddleware)] = new MiddlewareOrderRule
@@ -25,6 +26,12 @@ internal static class MiddlewareOrderValidator
             Priority = 200,
             ShouldComeAfter = new HashSet<Type> { typeof(CorrelationIdMiddleware) },
             Reason = "AsyncEffect should run after correlation and error handling are set up"
+        },
+        [typeof(ReactiveEffectMiddleware)] = new MiddlewareOrderRule
+        {
+            Priority = 210,
+            ShouldComeAfter = new HashSet<Type> { typeof(CorrelationIdMiddleware) },
+            Reason = "ReactiveEffect should run after correlation and error handling are set up"
         }
     };
 

--- a/src/library/Ducky/Reactive/Extensions/DuckyBuilderReactiveExtensions.cs
+++ b/src/library/Ducky/Reactive/Extensions/DuckyBuilderReactiveExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using Ducky.Builder;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Ducky.Reactive;
 
@@ -32,11 +33,6 @@ public static class DuckyBuilderReactiveExtensions
     /// <param name="builder">The Ducky store builder.</param>
     /// <param name="configure">Action to configure reactive effects.</param>
     /// <returns>The builder for chaining.</returns>
-    /// <remarks>
-    /// Important: This method only ensures the middleware is added. To actually register effects,
-    /// you must configure them in the IServiceCollection before calling AddDuckyStore.
-    /// Consider using AddDuckyStoreWithReactiveEffects extension method instead.
-    /// </remarks>
     public static DuckyBuilder AddReactiveEffects(
         this DuckyBuilder builder,
         Action<ReactiveEffectsBuilder> configure)
@@ -47,9 +43,9 @@ public static class DuckyBuilderReactiveExtensions
         // Add the reactive effect middleware
         builder.AddMiddleware<ReactiveEffectMiddleware>();
 
-        // WARNING: The configure action cannot be applied here because DuckyBuilder
-        // doesn't expose IServiceCollection. Effects must be registered separately.
-        // This overload exists for API compatibility but has limitations.
+        // Apply the configuration to register effects in DI
+        ReactiveEffectsBuilder effectsBuilder = new(builder.Services);
+        configure(effectsBuilder);
 
         return builder;
     }
@@ -60,17 +56,17 @@ public static class DuckyBuilderReactiveExtensions
     /// <typeparam name="TEffect">The type of reactive effect.</typeparam>
     /// <param name="builder">The Ducky store builder.</param>
     /// <returns>The builder for chaining.</returns>
-    /// <remarks>
-    /// Note: This method only ensures the middleware is added. The actual effect registration
-    /// must be done separately in the service collection before calling AddDuckyStore.
-    /// </remarks>
     public static DuckyBuilder AddReactiveEffect<TEffect>(this DuckyBuilder builder)
         where TEffect : ReactiveEffect
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        // Ensure middleware is added
+        // Auto-add ReactiveEffectMiddleware if not already present
         builder.AddMiddleware<ReactiveEffectMiddleware>();
+
+        // Register the effect in DI (mirrors AddEffect<T> pattern)
+        builder.Services.AddScoped<TEffect>();
+        builder.Services.AddScoped<ReactiveEffect>(sp => sp.GetRequiredService<TEffect>());
 
         return builder;
     }

--- a/src/library/Ducky/Reactive/Extensions/DuckyStoreConfigurationExtensions.cs
+++ b/src/library/Ducky/Reactive/Extensions/DuckyStoreConfigurationExtensions.cs
@@ -19,6 +19,7 @@ public static class DuckyStoreConfigurationExtensions
     /// <param name="configure">Action to configure the store builder.</param>
     /// <param name="configureEffects">Action to configure reactive effects.</param>
     /// <returns>The service collection for chaining.</returns>
+    [Obsolete("Use services.AddDucky(builder => builder.AddReactiveEffect<T>()) or builder.AddReactiveEffects(configure) instead.")]
     public static IServiceCollection AddDuckyStoreWithReactiveEffects(
         this IServiceCollection services,
         Action<DuckyBuilder> configure,

--- a/src/tests/Ducky.Blazor.Tests/MiddlewareIntegrationTestsSimplified.cs
+++ b/src/tests/Ducky.Blazor.Tests/MiddlewareIntegrationTestsSimplified.cs
@@ -78,7 +78,7 @@ public class MiddlewareIntegrationTestsSimplified : Bunit.BunitContext
         IMiddleware[] middlewares = scope.ServiceProvider.GetServices<IMiddleware>().ToArray();
         
         // Should have exactly 2 middlewares (no duplicates)
-        middlewares.Length.ShouldBe(2);
+        middlewares.Length.ShouldBe(3); // CorrelationId + AsyncEffect + ReactiveEffect (defaults)
         middlewares.ShouldContain(m => m is CorrelationIdMiddleware);
         middlewares.ShouldContain(m => m is AsyncEffectMiddleware);
     }
@@ -107,7 +107,7 @@ public class MiddlewareIntegrationTestsSimplified : Bunit.BunitContext
         store.ShouldNotBeNull();
         
         IMiddleware[] middlewares = scope.ServiceProvider.GetServices<IMiddleware>().ToArray();
-        middlewares.Length.ShouldBe(2);
+        middlewares.Length.ShouldBe(3); // CorrelationId + AsyncEffect + ReactiveEffect (defaults)
         middlewares.ShouldContain(m => m is CorrelationIdMiddleware);
         middlewares.ShouldContain(m => m is AsyncEffectMiddleware);
     }
@@ -175,7 +175,7 @@ public class MiddlewareIntegrationTestsSimplified : Bunit.BunitContext
         IMiddleware[] middlewares = scope.ServiceProvider.GetServices<IMiddleware>().ToArray();
 
         // AddDucky adds default middlewares, so we expect 2
-        middlewares.Length.ShouldBe(2);
+        middlewares.Length.ShouldBe(3); // CorrelationId + AsyncEffect + ReactiveEffect (defaults)
         middlewares.ShouldContain(m => m is CorrelationIdMiddleware);
         middlewares.ShouldContain(m => m is AsyncEffectMiddleware);
     }
@@ -247,7 +247,7 @@ public class MiddlewareIntegrationTestsSimplified : Bunit.BunitContext
         IMiddleware[] middlewares = scope.ServiceProvider.GetServices<IMiddleware>().ToArray();
         
         // Should have both CorrelationIdMiddleware and AsyncEffectMiddleware
-        middlewares.Length.ShouldBe(2);
+        middlewares.Length.ShouldBe(3); // CorrelationId + AsyncEffect + ReactiveEffect (defaults)
         middlewares.ShouldContain(m => m is CorrelationIdMiddleware);
         middlewares.ShouldContain(m => m is AsyncEffectMiddleware);
     }

--- a/src/tests/Ducky.Tests/Builder/ReactiveEffectRegistrationTests.cs
+++ b/src/tests/Ducky.Tests/Builder/ReactiveEffectRegistrationTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2020-2026 Atypical Consulting SRL. All rights reserved.
+// Atypical Consulting SRL licenses this file to you under the Apache-2.0 license.
+// See the LICENSE file in the project root for full license information.
+
+using Ducky.Middlewares.CorrelationId;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ducky.Tests.Builder;
+
+public class ReactiveEffectRegistrationTests
+{
+    [Fact]
+    public void AddReactiveEffect_ShouldRegisterBothConcreteTypeAndBaseClass()
+    {
+        // Arrange
+        ServiceCollection services = [];
+        services.AddLogging();
+
+        // Act
+        services.AddDucky(builder =>
+        {
+            builder.AddReactiveEffect<TestReactiveEffect>();
+        });
+
+        // Assert
+        services.Any(sd => sd.ServiceType == typeof(TestReactiveEffect)).ShouldBeTrue();
+        services.Any(sd => sd.ServiceType == typeof(ReactiveEffect)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddReactiveEffect_ShouldAutoAddReactiveEffectMiddleware()
+    {
+        // Arrange
+        ServiceCollection services = [];
+        services.AddLogging();
+
+        // Act
+        services.AddDucky(builder =>
+        {
+            builder
+                .AddMiddleware<CorrelationIdMiddleware>()
+                .AddReactiveEffect<TestReactiveEffect>();
+        });
+
+        // Assert
+        services.Any(sd => sd.ServiceType == typeof(ReactiveEffectMiddleware)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddReactiveEffects_WithConfigure_ShouldRegisterEffects()
+    {
+        // Arrange
+        ServiceCollection services = [];
+        services.AddLogging();
+
+        // Act
+        services.AddDucky(builder =>
+        {
+            builder.AddReactiveEffects(fx =>
+            {
+                fx.Add<TestReactiveEffect>();
+            });
+        });
+
+        // Assert
+        services.Any(sd => sd.ServiceType == typeof(TestReactiveEffect)).ShouldBeTrue();
+        services.Any(sd => sd.ServiceType == typeof(ReactiveEffect)).ShouldBeTrue();
+        services.Any(sd => sd.ServiceType == typeof(ReactiveEffectMiddleware)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddReactiveEffect_ShouldResolveAtRuntime()
+    {
+        // Arrange
+        ServiceCollection services = [];
+        services.AddLogging();
+        services.AddDucky(builder =>
+        {
+            builder.AddReactiveEffect<TestReactiveEffect>();
+        });
+
+        // Act
+        using ServiceProvider provider = services.BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        IEnumerable<ReactiveEffect> effects = scope.ServiceProvider.GetServices<ReactiveEffect>();
+
+        // Assert
+        List<ReactiveEffect> effectList = effects.ToList();
+        effectList.ShouldNotBeEmpty();
+        effectList.ShouldContain(e => e is TestReactiveEffect);
+    }
+
+    [Fact]
+    public void UseDefaultMiddlewares_ShouldIncludeReactiveEffectMiddleware()
+    {
+        // Arrange
+        ServiceCollection services = [];
+        services.AddLogging();
+
+        // Act
+        services.AddDucky(builder =>
+        {
+            builder.UseDefaultMiddlewares();
+        });
+
+        // Assert
+        services.Any(sd => sd.ServiceType == typeof(ReactiveEffectMiddleware)).ShouldBeTrue();
+        services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(3); // CorrelationId + AsyncEffect + ReactiveEffect
+    }
+
+    [Fact]
+    public void MiddlewareOrderValidator_ShouldAcceptReactiveEffectAfterCorrelationId()
+    {
+        // Arrange & Act - should not throw
+        ServiceCollection services = [];
+        services.AddLogging();
+
+        services.AddDucky(builder =>
+        {
+            builder
+                .AddMiddleware<CorrelationIdMiddleware>()
+                .AddReactiveEffect<TestReactiveEffect>();
+        });
+
+        // Assert - no exception thrown means order is valid
+        services.Any(sd => sd.ServiceType == typeof(ReactiveEffectMiddleware)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddReactiveEffect_ShouldWorkWithFluentChaining()
+    {
+        // Arrange
+        ServiceCollection services = [];
+        services.AddLogging();
+
+        // Act & Assert - Should compile and work with full fluent chain
+        services.AddDucky(builder =>
+        {
+            builder
+                .UseDefaultMiddlewares()
+                .AddSlice<TestStateReducers>()
+                .AddReactiveEffect<TestReactiveEffect>();
+        });
+
+        // Verify all registrations
+        services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(3); // Default middlewares
+        services.Any(sd => sd.ServiceType == typeof(ReactiveEffect)).ShouldBeTrue();
+    }
+
+    private class TestState : IState;
+
+    private sealed record TestStateReducers : SliceReducers<TestState>
+    {
+        public override TestState GetInitialState() => new();
+    }
+
+    // Test doubles
+    private class TestReactiveEffect : ReactiveEffect
+    {
+        public override IObservable<object> Handle(
+            IObservable<object> actions,
+            IObservable<IStateProvider> stateProvider)
+        {
+            return Observable.Empty<object>();
+        }
+    }
+}

--- a/src/tests/Ducky.Tests/Builder/StoreBuilderTests.cs
+++ b/src/tests/Ducky.Tests/Builder/StoreBuilderTests.cs
@@ -34,7 +34,7 @@ public class StoreBuilderTests
         List<ServiceDescriptor> middlewareServices = services.Where(sd => sd.ServiceType == typeof(IMiddleware)).ToList();
         // If this fails, uncomment the next line to see what middlewares are registered
         // var middlewareTypes = middlewareServices.Select(sd => sd.ImplementationType?.Name ?? sd.ImplementationFactory?.ToString() ?? "Unknown").ToList();
-        middlewareServices.Count.ShouldBe(2);
+        middlewareServices.Count.ShouldBe(3); // CorrelationId + AsyncEffect + ReactiveEffect (from defaults)
     }
 
     [Fact]
@@ -55,9 +55,9 @@ public class StoreBuilderTests
 
         // Assert - Should only register once
         services.Count(sd => sd.ServiceType == typeof(CorrelationIdMiddleware)).ShouldBe(1);
-        // Default middlewares (CorrelationId + AsyncEffect) are added automatically
+        // Default middlewares (CorrelationId + AsyncEffect + ReactiveEffect) are added automatically
         // Since we're trying to add CorrelationId again, it won't add a duplicate
-        services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(2); // CorrelationId + AsyncEffect from defaults
+        services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(3); // CorrelationId + AsyncEffect + ReactiveEffect from defaults
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class StoreBuilderTests
         });
 
         // Verify all registrations
-        services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(2); // Default middlewares
+        services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(3); // Default middlewares
         services.Any(sd => sd.ServiceType == typeof(ISlice)).ShouldBeTrue();
         services.Any(sd => sd.ServiceType == typeof(IAsyncEffect)).ShouldBeTrue();
         services.Any(sd => sd.ServiceType == typeof(IExceptionHandler)).ShouldBeTrue();

--- a/src/tests/Ducky.Tests/Integration/MiddlewareRegistrationTests.cs
+++ b/src/tests/Ducky.Tests/Integration/MiddlewareRegistrationTests.cs
@@ -28,7 +28,8 @@ public class MiddlewareRegistrationTests
         services.Any(sd => sd.ServiceType == typeof(AsyncEffectMiddleware)).ShouldBeTrue();
 
         // Also check that they are registered as IMiddleware
-        services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(2);
+        // Default middlewares include CorrelationId + AsyncEffect + ReactiveEffect
+        services.Count(sd => sd.ServiceType == typeof(IMiddleware)).ShouldBe(3);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fix broken `AddReactiveEffect<T>()` and `AddReactiveEffects(configure)` on `DuckyBuilder` — they only added middleware but never registered effects in DI
- Add `ReactiveEffectMiddleware` to default middlewares and assembly scanning
- Add middleware ordering rules, BlazorDuckyBuilder pass-through methods, and demo reactive effect
- Deprecate redundant `AddDuckyStoreWithReactiveEffects` entry point

Closes #192

## Acceptance Criteria
- [x] Clear documentation on when to use async vs reactive effects (CLAUDE.md updated)
- [x] Consider merging Ducky.Reactive into core Ducky (already merged; APIs now unified)
- [x] Effect registration API is consistent across both systems (`AddEffect<T>()` / `AddReactiveEffect<T>()`)
- [x] Demo app shows recommended patterns for common scenarios (CounterMilestoneReactiveEffect)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 426 tests pass (242 Ducky.Tests + 184 Ducky.Blazor.Tests)
- [x] New `ReactiveEffectRegistrationTests` verify DI registration, middleware auto-add, runtime resolution, fluent chaining
- [x] Existing test assertions updated for 3 default middlewares (CorrelationId + AsyncEffect + ReactiveEffect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)